### PR TITLE
Moved terminal mappings for easy disabling

### DIFF
--- a/lua/configs/toggleterm.lua
+++ b/lua/configs/toggleterm.lua
@@ -29,18 +29,6 @@ function M.config()
     },
   }))
 
-  function _G.set_terminal_keymaps()
-    local opts = { noremap = true }
-    vim.api.nvim_buf_set_keymap(0, "t", "<esc>", [[<C-\><C-n>]], opts)
-    vim.api.nvim_buf_set_keymap(0, "t", "jk", [[<C-\><C-n>]], opts)
-    vim.api.nvim_buf_set_keymap(0, "t", "<C-h>", [[<C-\><C-n><C-W>h]], opts)
-    vim.api.nvim_buf_set_keymap(0, "t", "<C-j>", [[<C-\><C-n><C-W>j]], opts)
-    vim.api.nvim_buf_set_keymap(0, "t", "<C-k>", [[<C-\><C-n><C-W>k]], opts)
-    vim.api.nvim_buf_set_keymap(0, "t", "<C-l>", [[<C-\><C-n><C-W>l]], opts)
-  end
-
-  vim.cmd "autocmd! TermOpen term://* lua set_terminal_keymaps()"
-
   local Terminal = require("toggleterm.terminal").Terminal
   local lazygit = Terminal:new { cmd = "lazygit", hidden = true }
 

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -160,4 +160,19 @@ map("x", "<A-k>", "<cmd>move '<-2<CR>gv-gv", opts)
 -- disable Ex mode:
 map("n", "Q", "<Nop>", opts)
 
+function _G.set_terminal_keymaps()
+  vim.api.nvim_buf_set_keymap(0, "t", "<esc>", [[<C-\><C-n>]], opts)
+  vim.api.nvim_buf_set_keymap(0, "t", "jk", [[<C-\><C-n>]], opts)
+  vim.api.nvim_buf_set_keymap(0, "t", "<C-h>", [[<C-\><C-n><C-W>h]], opts)
+  vim.api.nvim_buf_set_keymap(0, "t", "<C-j>", [[<C-\><C-n><C-W>j]], opts)
+  vim.api.nvim_buf_set_keymap(0, "t", "<C-k>", [[<C-\><C-n><C-W>k]], opts)
+  vim.api.nvim_buf_set_keymap(0, "t", "<C-l>", [[<C-\><C-n><C-W>l]], opts)
+end
+
+vim.cmd [[
+  augroup TermMappings
+    autocmd! TermOpen term://* lua set_terminal_keymaps()
+  augroup END
+]]
+
 return M


### PR DESCRIPTION
Moved the terminal mappings to the `mappings.lua` file as well as put them in an `augroup` so the user can easily disable them.