### PR TITLE
Fix lsp config to v0.1.3

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -227,6 +227,7 @@ local astro_plugins = {
   -- Built-in LSP
   {
     "neovim/nvim-lspconfig",
+    tag = "v0.1.3",
     event = "BufWinEnter",
     config = function()
       require "configs.lsp"


### PR DESCRIPTION
`nvim-lspconfig` is about to do a bunch of breaking changes with adding v0.7 support. We will need to keep this commit tagged until those changes get merged in and we can update the config to fix the breaking part.