### PR TITLE
Add descriptions to user commands

### DIFF
--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -72,7 +72,7 @@ M.on_attach = function(client, bufnr)
     on_attach_override(client, bufnr)
   end
 
-  vim.api.nvim_create_user_command("Format", vim.lsp.buf.formatting, {})
+  vim.api.nvim_create_user_command("Format", vim.lsp.buf.formatting, { desc = "Format file with LSP" })
   lsp_highlight_document(client)
 end
 

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -62,6 +62,6 @@ if utils.is_available "dashboard-nvim" then
   })
 end
 
-create_command("AstroUpdate", require("core.utils").update, {})
+create_command("AstroUpdate", require("core.utils").update, { desc = "Update AstroNvim" })
 
 return M


### PR DESCRIPTION
This gives command descriptions that look nice when searching commands with something like `:Telescope commands`