### PR TITLE
Add ability for easy lsp setup without lsp installer

### DIFF
--- a/lua/configs/lsp/init.lua
+++ b/lua/configs/lsp/init.lua
@@ -1,5 +1,10 @@
 local status_ok, _ = pcall(require, "lspconfig")
 if status_ok then
   require "configs.lsp.lsp-installer"
-  require("configs.lsp.handlers").setup()
+  local handlers = require "configs.lsp.handlers"
+  handlers.setup()
+  local lsp_setup = require("core.utils").user_plugin_opts "lsp.setup"
+  if type(lsp_setup) == "function" then
+    lsp_setup(handlers.on_attach, handlers.capabilities)
+  end
 end


### PR DESCRIPTION
Resolves #343

This adds the ability for easily setting up language servers without LSP installer either because LSP installer doesn't support installing the server or if the user just already has the server installed on their machine. Here is an example `user/init.lua` for adding `pyright` to the LSP config where the user already has `pyright` installed and doesn't want to use `lsp-installer`:

```lua
return {
  lsp = {
    setup = function(on_attach, capabilities)
      require("lspconfig").pyright.setup {
        on_attach = on_attach,
        capabilities = capabilities,
      }
    end,
  },
}
```