### PR TITLE
Fix plugin name in settings

### DIFF
--- a/lua/configs/comment.lua
+++ b/lua/configs/comment.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.config()
   local status_ok, comment = pcall(require, "Comment")
   if status_ok then
-    comment.setup(require("core.utils").user_plugin_opts("plugins.Comment", {
+    comment.setup(require("core.utils").user_plugin_opts("plugins.comment", {
       pre_hook = function(ctx)
         local U = require "Comment.utils"
 


### PR DESCRIPTION
### Hey
When I customize comment plugin I have a troubles.
I create file **lua/user/plugins/comment.lua** **(name give like in the config directory)** for add new rule, but this not worked for me.

I thought be good idea to browse AstroNvim's default config. I go to this the file and see that name of user setter config been set's **"plugins.Comment"**.

Why user config file name and your different?

I think that you when write this config you copy-paste and you just didn't notice.
Just not good if default config file name and user's will be different