### PR TITLE
Replace lazygit with gitui

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ git -C ~/.config/nvim remote set-url origin https://github.com/AstroNvim/AstroNv
 - Terminal with true color support (for the default theme, otherwise it is dependent on the theme you are using)
 - Optional Requirements:
   - [ripgrep](https://github.com/BurntSushi/ripgrep) - live grep telescope search (`<leader>fw`)
-  - [lazygit](https://github.com/jesseduffield/lazygit) - git ui toggle terminal (`<leader>tl` or `<leader>gg`)
+  - [gitui](https://github.com/extrawurst/gitui) - git ui toggle terminal (`<leader>tg` or `<leader>gg`)
   - [NCDU](https://dev.yorhel.nl/ncdu) - disk usage toggle terminal (`<leader>tu`)
   - [Htop](https://htop.dev/) - process viewer toggle terminal (`<leader>tt`)
   - [Python](https://www.python.org/) - python repl toggle terminal (`<leader>tp`)

--- a/lua/configs/which-key-register.lua
+++ b/lua/configs/which-key-register.lua
@@ -156,9 +156,9 @@ if status_ok then
     init_table("n", "<leader>", "g")
     mappings.n["<leader>"].g.g = {
       function()
-        require("core.utils").toggle_term_cmd "lazygit"
+        require("core.utils").toggle_term_cmd "gitui"
       end,
-      "Lazygit",
+      "GitUI",
     }
 
     init_table("n", "<leader>", "t")
@@ -186,11 +186,11 @@ if status_ok then
       end,
       "Python",
     }
-    mappings.n["<leader>"].t.l = {
+    mappings.n["<leader>"].t.g = {
       function()
-        require("core.utils").toggle_term_cmd "lazygit"
+        require("core.utils").toggle_term_cmd "gitui"
       end,
-      "Lazygit",
+      "GitUI",
     }
     mappings.n["<leader>"].t.f = { "<cmd>ToggleTerm direction=float<cr>", "Float" }
     mappings.n["<leader>"].t.h = { "<cmd>ToggleTerm size=10 direction=horizontal<cr>", "Horizontal" }

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -228,8 +228,8 @@ if not utils.is_available "which-key.nvim" then
   -- Terminal
   if utils.is_available "nvim-toggleterm.lua" then
     map("n", "<leader>gg", function()
-      utils.toggle_term_cmd "lazygit"
-    end, { desc = "ToggleTerm lazygit" })
+      utils.toggle_term_cmd "gitui"
+    end, { desc = "ToggleTerm gitui" })
     map("n", "<leader>tn", function()
       utils.toggle_term_cmd "node"
     end, { desc = "ToggleTerm node" })
@@ -242,9 +242,9 @@ if not utils.is_available "which-key.nvim" then
     map("n", "<leader>tp", function()
       utils.toggle_term_cmd "python"
     end, { desc = "ToggleTerm python" })
-    map("n", "<leader>tl", function()
-      utils.toggle_term_cmd "lazygit"
-    end, { desc = "ToggleTerm lazygit" })
+    map("n", "<leader>tg", function()
+      utils.toggle_term_cmd "gitui"
+    end, { desc = "ToggleTerm gitui" })
     map("n", "<leader>tf", "<cmd>ToggleTerm direction=float<cr>", { desc = "ToggleTerm float" })
     map("n", "<leader>th", "<cmd>ToggleTerm size=10 direction=horizontal<cr>", { desc = "ToggleTerm horizontal split" })
     map("n", "<leader>tv", "<cmd>ToggleTerm size=80 direction=vertical<cr>", { desc = "ToggleTerm vertical split" })


### PR DESCRIPTION
[GitUI](https://github.com/extrawurst/gitui) is a TUI for git that appears  to be a better (IMO) replacement for lazygit in terms of functionality and performance (see benchmark comparisons of gitui vs lazygit in the project's readme).

This PR replaces lazygit with gitui.  GitUI is 
- MIT licensed
- Written in rust, is cross-platform, and has unit test and CI pipelines
- easily installable by the user via multiple methods (package managers such as cargo, brew, nix, scoop, chocolatey etc. or can use one of the pre-built binaries provided for many platforms).

This PR replaces `lazygit` with `gitui` in AstroNvim. One of the toggle-term key binding is changed to `<leader>tg` for consistent mnemonics. I have tested `gitui` on various large repos and didn't find any issues. The maintainers of AstroNVim (and other community users) could perhaps do further testing on their own git projects before considering merging this PR.