### PR TITLE
Add LSP Extension Plugin Compatibility

### DIFF
--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -62,7 +62,7 @@ M.on_attach = function(client, bufnr)
   end
 
   local on_attach_override = require("core.utils").user_plugin_opts "lsp.on_attach"
-  if on_attach_override ~= nil then
+  if type(on_attach_override) == "function" then
     on_attach_override(client, bufnr)
   end
 

--- a/lua/configs/lsp/init.lua
+++ b/lua/configs/lsp/init.lua
@@ -13,7 +13,16 @@ if status_ok then
     end
   end
   for _, server in ipairs(servers) do
-    local opts = { on_attach = handlers.on_attach, capabilities = handlers.capabilities }
+    local old_on_attach = lspconfig[server].on_attach
+    local opts = {
+      on_attach = function(client, bufnr)
+        if old_on_attach then
+          old_on_attach(client, bufnr)
+        end
+        handlers.on_attach(client, bufnr)
+      end,
+      capabilities = vim.tbl_deep_extend("force", handlers.capabilities, lspconfig[server].capabilities or {}),
+    }
     local present, av_overrides = pcall(require, "configs.lsp.server-settings." .. server)
     if present then
       opts = vim.tbl_deep_extend("force", av_overrides, opts)


### PR DESCRIPTION
If a plugin sets up LSP specific capabilities and on_attach functions then we should respect that when we call our own language server setups.