### PR TITLE
Defer plugins and load asynchronously

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -64,6 +64,10 @@ if packer_status_ok then
     -- Icons
     {
       "kyazdani42/nvim-web-devicons",
+      opt = true,
+      setup = function()
+        require("core.utils").defer_plugin "nvim-web-devicons"
+      end,
       config = function()
         require("configs.icons").config()
       end,
@@ -82,6 +86,7 @@ if packer_status_ok then
     -- Better buffer closing
     {
       "moll/vim-bbye",
+      cmd = { "Bdelete", "Bwipeout" },
     },
 
     -- File explorer
@@ -208,7 +213,14 @@ if packer_status_ok then
     -- LSP manager
     {
       "williamboman/nvim-lsp-installer",
-      event = "BufWinEnter",
+      module = "lspconfig",
+      opt = true,
+      setup = function()
+        require("core.utils").defer_plugin "nvim-lsp-installer"
+        vim.defer_fn(function()
+          vim.cmd 'if &ft == "packer" | echo "" | else | silent! e %'
+        end, 0)
+      end,
       config = function()
         require("configs.nvim-lsp-installer").config()
       end,
@@ -269,7 +281,10 @@ if packer_status_ok then
     -- Git integration
     {
       "lewis6991/gitsigns.nvim",
-      event = { "BufRead", "BufNewFile" },
+      opt = true,
+      setup = function()
+        require("core.utils").defer_plugin "gitsigns.nvim"
+      end,
       config = function()
         require("configs.gitsigns").config()
       end,
@@ -337,6 +352,10 @@ if packer_status_ok then
     -- Keymaps popup
     {
       "folke/which-key.nvim",
+      opt = true,
+      setup = function()
+        require("core.utils").defer_plugin "which-key.nvim"
+      end,
       config = function()
         require("configs.which-key").config()
       end,

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -96,11 +96,13 @@ function M.bootstrap()
 end
 
 function M.disabled_builtins()
+  g.load_black = false
   g.loaded_2html_plugin = false
   g.loaded_getscript = false
   g.loaded_getscriptPlugin = false
   g.loaded_gzip = false
   g.loaded_logipat = false
+  g.loaded_matchit = true
   g.loaded_netrwFileHandlers = false
   g.loaded_netrwPlugin = false
   g.loaded_netrwSettngs = false
@@ -212,6 +214,12 @@ function M.label_plugins(plugins)
     labelled[plugin[1]] = plugin
   end
   return labelled
+end
+
+function M.defer_plugin(plugin, timeout)
+  vim.defer_fn(function()
+    require("packer").loader(plugin)
+  end, timeout or 0)
 end
 
 function M.is_available(plugin)


### PR DESCRIPTION
For some of our plugins that add some startup time but we want them to load on startup we can defer their start up and load them asynchronously to speed up opening.