### PR TITLE
Move from Symbols Outline to Aerial

### DIFF
--- a/lua/configs/aerial.lua
+++ b/lua/configs/aerial.lua
@@ -1,0 +1,47 @@
+local M = {}
+
+function M.config()
+  local present, aerial = pcall(require, "aerial")
+  if present then
+    aerial.setup(require("core.utils").user_plugin_opts("plugins.aerial", {
+      close_behavior = "global",
+      backends = { "lsp", "treesitter", "markdown" },
+      min_width = 35,
+      show_guides = true,
+      filter_kind = {
+        "Class",
+        "Constructor",
+        "Enum",
+        "Function",
+        "Interface",
+        "Module",
+        "Method",
+        "Struct",
+        "Variable",
+      },
+      icons = {
+        Array = " ",
+        Boolean = "⊨ ",
+        Class = "𝓒 ",
+        Key = "🔐 ",
+        Namespace = " ",
+        Null = "NULL ",
+        Number = "# ",
+        Object = "⦿ ",
+        Property = " ",
+        TypeParameter = "𝙏 ",
+        Variable = " ",
+      },
+      on_attach = function(bufnr)
+        -- Jump forwards/backwards with '{' and '}'
+        vim.keymap.set("n", "{", "<cmd>ArialPrev<cr>", { buffer = bufnr, desc = "Jump backwards in Aerial" })
+        vim.keymap.set("n", "}", "<cmd>ArialNext<cr>", { buffer = bufnr, desc = "Jump forwards in Aerial" })
+        -- Jump up the tree with '[[' or ']]'
+        vim.keymap.set("n", "[[", "<cmd>ArialPrevUp<cr>", { buffer = bufnr, desc = "Jump up and backwards in Aerial" })
+        vim.keymap.set("n", "]]", "<cmd>ArialNextUp<cr>", { buffer = bufnr, desc = "Jump up and forwards in Aerial" })
+      end,
+    }))
+  end
+end
+
+return M

--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -66,6 +66,10 @@ M.on_attach = function(client, bufnr)
     on_attach_override(client, bufnr)
   end
 
+  local aerial_avail, aerial = pcall(require, "aerial")
+  if aerial_avail then
+    aerial.on_attach(client, bufnr)
+  end
   vim.api.nvim_create_user_command("Format", vim.lsp.buf.formatting, { desc = "Format file with LSP" })
   lsp_highlight_document(client)
 end

--- a/lua/configs/symbols-outline.lua
+++ b/lua/configs/symbols-outline.lua
@@ -1,9 +1,0 @@
-local M = {}
-
-function M.setup()
-  vim.g.symbols_outline = require("core.utils").user_plugin_opts("plugins.symbols_outline", {
-    width = 17,
-  })
-end
-
-return M

--- a/lua/configs/which-key-register.lua
+++ b/lua/configs/which-key-register.lua
@@ -198,9 +198,9 @@ if status_ok then
     mappings.n["<leader>"].t.v = { "<cmd>ToggleTerm size=80 direction=vertical<cr>", "Vertical" }
   end
 
-  if utils.is_available "symbols-outline.nvim" then
+  if utils.is_available "aerial.nvim" then
     init_table("n", "<leader>", "l")
-    mappings.n["<leader>"].l.S = { "<cmd>SymbolsOutline<CR>", "Symbols Outline" }
+    mappings.n["<leader>"].l.S = { "<cmd>AerialToggle<CR>", "Symbols Outline" }
   end
 
   if utils.is_available "telescope.nvim" then

--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -251,8 +251,8 @@ if not utils.is_available "which-key.nvim" then
   end
 
   -- SymbolsOutline
-  if utils.is_available "symbols-outline.nvim" then
-    map("n", "<leader>lS", "<cmd>SymbolsOutline<CR>", { desc = "Symbols outline" })
+  if utils.is_available "aerial.nvim" then
+    map("n", "<leader>lS", "<cmd>AerialToggle<CR>", { desc = "Symbols outline" })
   end
 end
 

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -229,12 +229,14 @@ if packer_status_ok then
 
     -- LSP symbols
     {
-      "simrat39/symbols-outline.nvim",
-      cmd = "SymbolsOutline",
+      "stevearc/aerial.nvim",
+      opt = true,
       setup = function()
-        require("configs.symbols-outline").setup()
+        require("core.utils").defer_plugin "aerial.nvim"
       end,
-      disable = not config.enabled.symbols_outline,
+      config = function()
+        require("configs.aerial").config()
+      end,
     },
 
     -- Formatting and linting

--- a/lua/default_theme/others.lua
+++ b/lua/default_theme/others.lua
@@ -241,6 +241,23 @@ local others = {
 
   -- HightlightURL
   HighlightURL = { underline = true },
+
+  -- Aerial
+  AerialLine = { fg = C.yellow, bg = C.none },
+  AerialGuide = { fg = C.blue_3 },
+  AerialBooleanIcon = { link = "TSBoolean" },
+  AerialConstantIcon = { link = "TSConstant" },
+  AerialConstructorIcon = { link = "TSConstructor" },
+  AerialFieldIcon = { link = "TSField" },
+  AerialFunctionIcon = { link = "TSFunction" },
+  AerialMethodIcon = { link = "TSMethod" },
+  AerialNamespaceIcon = { link = "TSNamespace" },
+  AerialNumberIcon = { link = "TSNumber" },
+  AerialOperatorIcon = { link = "TSOperator" },
+  AerialTypeParameterIcon = { link = "TSParameter" },
+  AerialPropertyIcon = { link = "TSProperty" },
+  AerialStringIcon = { link = "TSString" },
+  AerialVariableIcon = { link = "TSVariable" },
 }
 
 return others


### PR DESCRIPTION
This is a work in progress PR for moving to Aerial from Symbols Outline for more general support with Treesitter.

# TODO

- [x] investigate padding to make it look nicer (not currently an option)
- [x] figure out what symbols we want to show up since Symbols Outline assumes all we can make this better
- [x] add highlight groups
- [x] profit

Resolves #377