### PR TITLE
Unpin lspconfig

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -215,7 +215,6 @@ if packer_status_ok then
       setup = function()
         require("core.utils").defer_plugin "nvim-lspconfig"
       end,
-      tag = "v0.1.3",
     },
 
     -- LSP manager


### PR DESCRIPTION
We can unpin `lspconfig` I did some testing with the v0.7 branch and we are fully compatible and won't have any breaking changes when https://github.com/neovim/nvim-lspconfig/pull/1838 get's merged