### PR TITLE
Removed deprecated LSP resolved_capabilities

### DIFF
--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -42,7 +42,7 @@ function M.setup()
 end
 
 local function lsp_highlight_document(client)
-  if client.resolved_capabilities.document_highlight then
+  if client.server_capabilities.documentHighlightProvider then
     vim.api.nvim_create_augroup("lsp_document_highlight", {})
     vim.api.nvim_create_autocmd("CursorHold", {
       group = "lsp_document_highlight",
@@ -59,7 +59,10 @@ end
 
 M.on_attach = function(client, bufnr)
   if client.name == "tsserver" or client.name == "jsonls" or client.name == "html" or client.name == "sumneko_lua" then
-    client.resolved_capabilities.document_formatting = false
+    if vim.fn.has "nvim-0.7" then -- needed for formatting checker in <0.8
+      client.resolved_capabilities.document_formatting = false
+    end
+    client.server_capabilities.documentFormattingProvider = false
   end
 
   local on_attach_override = require("core.utils").user_plugin_opts "lsp.on_attach"

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -159,7 +159,7 @@ local config = {
       },
       -- NOTE: You can remove this on attach function to disable format on save
       on_attach = function(client)
-        if client.resolved_capabilities.document_formatting then
+        if client.server_capabilities.documentFormattingProvider then
           vim.api.nvim_create_autocmd("BufWritePre", {
             desc = "Auto format before save",
             pattern = "<buffer>",


### PR DESCRIPTION
I did  some more investigation into the resolved_capabilities deprecation as shown  by #421 and the new approach is almost supported by neovim 0.7. It appears the  formatter does check the `resolved_capabilities` so we need one of the deprecated approaches still  but we can check for neovim version. I think it's a good idea to move to this approach  now.