### PR TITLE
Streamline options setting and automatically check for colorscheme

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -8,7 +8,6 @@ local augroup = vim.api.nvim_create_augroup
 
 -- Remap space as leader key
 map("", "<Space>", "<Nop>")
-vim.g.mapleader = " "
 
 -- Normal --
 if utils.is_available "smart-splits.nvim" then

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -1,46 +1,58 @@
 local M = {}
 
-local utils = require "core.utils"
-local colorscheme = utils.user_plugin_opts "colorscheme"
+local user_plugin_opts = require("core.utils").user_plugin_opts
 
-local set = vim.opt
-local g = vim.g
-
+local colorscheme = user_plugin_opts "colorscheme"
+if not vim.tbl_contains(vim.fn.getcompletion("", "color"), colorscheme) then
+  colorscheme = require("core.defaults").colorscheme
+end
 vim.api.nvim_command(("colorscheme %s"):format(colorscheme))
 
-set.clipboard = "unnamedplus" -- Connection to the system clipboard
-set.completeopt = { "menuone", "noselect" } -- Options for insert mode completion
-set.copyindent = true -- Copy the previous indentation on autoindenting
-set.cursorline = true -- Highlight the text line of the cursor
-set.expandtab = true -- Enable the use of space in tab
-set.fileencoding = "utf-8" -- File content encoding for the buffer
-set.fillchars = { eob = " " } -- Disable `~` on nonexistent lines
-set.history = 100 -- Number of commands to remember in a history table
-set.ignorecase = true -- Case insensitive searching
-set.mouse = "a" -- Enable mouse support
-set.number = true -- Show numberline
-set.preserveindent = true -- Preserve indent structure as much as possible
-set.pumheight = 10 -- Height of the pop up menu
-set.relativenumber = true -- Show relative numberline
-set.scrolloff = 8 -- Number of lines to keep above and below the cursor
-set.shiftwidth = 2 -- Number of space inserted for indentation
-set.showmode = false -- Disable showing modes in command line
-set.sidescrolloff = 8 -- Number of columns to keep at the sides of the cursor
-set.signcolumn = "yes" -- Always show the sign column
-set.smartcase = true -- Case sensitivie searching
-set.splitbelow = true -- Splitting a new window below the current one
-set.splitright = true -- Splitting a new window at the right of the current one
-set.swapfile = false -- Disable use of swapfile for the buffer
-set.tabstop = 2 -- Number of space in a tab
-set.termguicolors = true -- Enable 24-bit RGB color in the TUI
-set.timeoutlen = 300 -- Length of time to wait for a mapped sequence
-set.undofile = true -- Enable persistent undo
-set.updatetime = 300 -- Length of time to wait before triggering the plugin
-set.wrap = false -- Disable wrapping of lines longer than the width of window
-set.writebackup = false -- Disable making a backup before overwriting a file
+local options = user_plugin_opts("options", {
+  opt = {
+    clipboard = "unnamedplus", -- Connection to the system clipboard
+    completeopt = { "menuone", "noselect" }, -- Options for insert mode completion
+    copyindent = true, -- Copy the previous indentation on autoindenting
+    cursorline = true, -- Highlight the text line of the cursor
+    expandtab = true, -- Enable the use of space in tab
+    fileencoding = "utf-8", -- File content encoding for the buffer
+    fillchars = { eob = " " }, -- Disable `~` on nonexistent lines
+    history = 100, -- Number of commands to remember in a history table
+    ignorecase = true, -- Case insensitive searching
+    mouse = "a", -- Enable mouse support
+    number = true, -- Show numberline
+    preserveindent = true, -- Preserve indent structure as much as possible
+    pumheight = 10, -- Height of the pop up menu
+    relativenumber = true, -- Show relative numberline
+    scrolloff = 8, -- Number of lines to keep above and below the cursor
+    shiftwidth = 2, -- Number of space inserted for indentation
+    showmode = false, -- Disable showing modes in command line
+    sidescrolloff = 8, -- Number of columns to keep at the sides of the cursor
+    signcolumn = "yes", -- Always show the sign column
+    smartcase = true, -- Case sensitivie searching
+    splitbelow = true, -- Splitting a new window below the current one
+    splitright = true, -- Splitting a new window at the right of the current one
+    swapfile = false, -- Disable use of swapfile for the buffer
+    tabstop = 2, -- Number of space in a tab
+    termguicolors = true, -- Enable 24-bit RGB color in the TUI
+    timeoutlen = 300, -- Length of time to wait for a mapped sequence
+    undofile = true, -- Enable persistent undo
+    updatetime = 300, -- Length of time to wait before triggering the plugin
+    wrap = false, -- Disable wrapping of lines longer than the width of window
+    writebackup = false, -- Disable making a backup before overwriting a file
+  },
+  g = {
+    do_filetype_lua = 1, -- use filetype.lua
+    did_load_filetypes = 0, -- don't use filetype.vim
+    highlighturl_enabled = true, -- highlight URLs by default
+    mapleader = " ", -- set leader key
+  },
+})
 
-g.do_filetype_lua = 1 -- use filetype.lua
-g.did_load_filetypes = 0 -- don't use filetype.vim
-g.highlighturl_enabled = true -- highlight URLs by default
+for scope, table in pairs(options) do
+  for setting, value in pairs(table) do
+    vim[scope][setting] = value
+  end
+end
 
 return M

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -210,6 +210,9 @@ end
 
 function M.alpha_button(sc, txt)
   local sc_ = sc:gsub("%s", ""):gsub("LDR", "<leader>")
+  if vim.g.mapleader then
+    sc = sc:gsub("LDR", vim.g.mapleader == " " and "SPC" or vim.g.mapleader)
+  end
   return {
     type = "button",
     val = txt,

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -3,6 +3,16 @@ local config = {
   -- Set colorscheme
   colorscheme = "default_theme",
 
+  -- set vim options here (vim.<first_key>.<second_key> =  value)
+  options = {
+    opt = {
+      relativenumber = true, -- sets vim.opt.relativenumber
+    },
+    g = {
+      mapleader = " ", -- sets vim.g.mapleader
+    },
+  },
+
   -- Default theme configuration
   default_theme = {
     diagnostics_style = { italic = true },
@@ -173,13 +183,8 @@ local config = {
   -- This function is run last
   -- good place to configure mappings and vim options
   polish = function()
-    local map = vim.keymap.set
-    local set = vim.opt
-    -- Set options
-    set.relativenumber = true
-
     -- Set key bindings
-    map("n", "<C-s>", ":w!<CR>")
+    vim.keymap.set("n", "<C-s>", ":w!<CR>")
 
     -- Set autocommands
     vim.api.nvim_create_augroup("packer_conf", {})


### PR DESCRIPTION
This streamlines vim options setting into a nice API. Also since we are setting user options first then we can use it to guide the Alpha welcome screen text.

Also this adds checking for if a colorscheme is installed. So the user no longer has to worry about checking if their plugin is loaded themselves.