### PR TITLE
add fallback mappings for split movement and resize

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -38,6 +38,15 @@ if utils.is_available "smart-splits.nvim" then
   map("n", "<C-Right>", function()
     require("smart-splits").resize_right()
   end, { desc = "Resize split right" })
+else
+  map("n", "<C-h>", "<C-w>h", { desc = "Move to left split" })
+  map("n", "<C-j>", "<C-w>j", { desc = "Move to below split" })
+  map("n", "<C-k>", "<C-w>k", { desc = "Move to above split" })
+  map("n", "<C-l>", "<C-w>l", { desc = "Move to right split" })
+  map("n", "<C-Up>", "<cmd>resize -2<CR>", { desc = "Resize split up" })
+  map("n", "<C-Down>", "<cmd>resize +2<CR>", { desc = "Resize split down" })
+  map("n", "<C-Left>", "<cmd>vertical resize -2<CR>", { desc = "Resize split left" })
+  map("n", "<C-Right>", "<cmd>vertical resize +2<CR>", { desc = "Resize split right" })
 end
 
 -- Navigate buffers


### PR DESCRIPTION
This adds basic split mappings if smart split is removed.