### PR TITLE
Remove cursorline autocommands

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -6,22 +6,6 @@ local cmd = vim.api.nvim_create_autocmd
 local augroup = vim.api.nvim_create_augroup
 local create_command = vim.api.nvim_create_user_command
 
-augroup("cursor_off", { clear = true })
-cmd("BufLeave", {
-  desc = "No cursorline",
-  group = "cursor_off",
-  callback = function()
-    vim.opt.cursorline = false
-  end,
-})
-cmd({ "BufEnter", "FileType" }, {
-  desc = "No cursorline",
-  group = "cursor_off",
-  callback = function()
-    vim.opt.cursorline = not vim.tbl_contains({ "alpha", "TelescopePrompt" }, vim.bo.filetype)
-  end,
-})
-
 augroup("highlighturl", { clear = true })
 cmd({ "VimEnter", "FileType", "BufEnter", "WinEnter" }, {
   desc = "URL Highlighting",


### PR DESCRIPTION
These auto commands are causing more harm than good. I think for now it's a good idea to remove them.