### PR TITLE
Bufferline reorder buffer mappings

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -53,8 +53,8 @@ end
 if utils.is_available "bufferline.nvim" then
   map("n", "<S-l>", "<cmd>BufferLineCycleNext<cr>", { desc = "Next buffer tab" })
   map("n", "<S-h>", "<cmd>BufferLineCyclePrev<cr>", { desc = "Previous buffer tab" })
-  map("n", "}", "<cmd>BufferLineMoveNext<cr>", { desc = "Move buffer tab right" })
-  map("n", "{", "<cmd>BufferLineMovePrev<cr>", { desc = "Move buffer tab left" })
+  map("n", ">b", "<cmd>BufferLineMoveNext<cr>", { desc = "Move buffer tab right" })
+  map("n", "<b", "<cmd>BufferLineMovePrev<cr>", { desc = "Move buffer tab left" })
 else
   map("n", "<S-l>", "<cmd>bnext<cr>", { desc = "Next buffer" })
   map("n", "<S-h>", "<cmd>bprevious<cr>", { desc = "Previous buffer" })


### PR DESCRIPTION
Our current bindings are really bad conflicts. This puts them in logical mappings that don't conflict with the indentation command