### PR TITLE
Revert back to just using resolved_capabilities

### DIFF
--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -42,7 +42,7 @@ function M.setup()
 end
 
 local function lsp_highlight_document(client)
-  if client.server_capabilities.documentHighlightProvider then
+  if client.resolved_capabilities.document_highlight then
     vim.api.nvim_create_augroup("lsp_document_highlight", { clear = true })
     vim.api.nvim_create_autocmd("CursorHold", {
       group = "lsp_document_highlight",
@@ -59,10 +59,7 @@ end
 
 M.on_attach = function(client, bufnr)
   if client.name == "tsserver" or client.name == "jsonls" or client.name == "html" or client.name == "sumneko_lua" then
-    if vim.fn.has "nvim-0.7" then -- needed for formatting checker in <0.8
-      client.resolved_capabilities.document_formatting = false
-    end
-    client.server_capabilities.documentFormattingProvider = false
+    client.resolved_capabilities.document_formatting = false
   end
 
   local on_attach_override = require("core.utils").user_plugin_opts "lsp.on_attach"

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -169,7 +169,7 @@ local config = {
       },
       -- NOTE: You can remove this on attach function to disable format on save
       on_attach = function(client)
-        if client.server_capabilities.documentFormattingProvider then
+        if client.resolved_capabilities.document_formatting then
           vim.api.nvim_create_augroup("lsp_format", { clear = true })
           vim.api.nvim_create_autocmd("BufWritePre", {
             desc = "Auto format before save",


### PR DESCRIPTION
It appears not every language server is setting the `server_capabilities` quite yet. So we should revert this for more consistency 