### PR TITLE
Add lazy loading to alpha

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -28,6 +28,30 @@ if utils.is_available "alpha-nvim" then
     pattern = "alpha",
     command = "set laststatus=0 | autocmd BufUnload <buffer> set laststatus=3",
   })
+  cmd("VimEnter", {
+    desc = "Start Alpha when vim is opened with no arguments",
+    group = "alpha_settings",
+    callback = function()
+      -- optimized start check from https://github.com/goolord/alpha-nvim
+      local should_skip = false
+      if vim.fn.argc() > 0 or vim.fn.line2byte "$" ~= -1 or not vim.o.modifiable then
+        should_skip = true
+      else
+        for _, arg in pairs(vim.v.argv) do
+          if arg == "-b" or arg == "-c" or vim.startswith(arg, "+") or arg == "-S" then
+            should_skip = true
+            break
+          end
+        end
+      end
+      if not should_skip then
+        local alpha_avail, alpha = pcall(require, "alpha")
+        if alpha_avail then
+          alpha.start(false)
+        end
+      end
+    end,
+  })
 end
 
 create_command("AstroUpdate", require("core.utils").update, { desc = "Update AstroNvim" })

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -274,6 +274,8 @@ if packer_status_ok then
     -- Start screen
     {
       "goolord/alpha-nvim",
+      cmd = "Alpha",
+      module = "alpha",
       config = function()
         require("configs.alpha").config()
       end,


### PR DESCRIPTION
This takes a first stab at lazy loading alpha if neovim is opened with a file.

This lazy loading is not quite as sophisticated as the alpha starting conditions.

Resolves #471 