### PR TITLE
fixed require for indent-line.lua

### DIFF
--- a/lua/configs/indent-line.lua
+++ b/lua/configs/indent-line.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.setup()
-  require("utils").vim_opts {
+  require("core.utils").vim_opts {
     g = {
       indentLine_enabled = 1,
       indent_blankline_show_trailing_blankline_indent = false,


### PR DESCRIPTION
At the moment installing AstroNvim gives following error:
![astrovim-error](https://i.imgur.com/JAmDxeO.png)

This PR should fix this.