### PR TITLE
Don't show which-key popup when Telescope window is opened

### DIFF
--- a/lua/configs/which-key.lua
+++ b/lua/configs/which-key.lua
@@ -3,6 +3,14 @@ local M = {}
 function M.config()
   local status_ok, which_key = pcall(require, "which-key")
   if status_ok then
+    -- Don't show which-key popup when Telescope is opened
+    local show = which_key.show
+    which_key.show = function(keys, opts)
+      if vim.bo.filetype == "TelescopePrompt" then
+        return
+      end
+      show(keys, opts)
+    end
     which_key.setup(require("core.utils").user_plugin_opts("plugins.which-key", {
       plugins = {
         spelling = { enabled = true },


### PR DESCRIPTION
When Telescope window is opened, in normal mode, if we press `<leader>` key (SPC by default). It will show an error like below:

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/79964592/167295328-1f5f2e49-eb5e-4b08-8fcf-076fb630d966.png">

This fix is disable which-key popup when Telescope is still opened.