### PR TITLE
Use Main branch for BufferLine and ToggleTerm

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -67,6 +67,7 @@ if packer_status_ok then
     -- Bufferline
     {
       "akinsho/bufferline.nvim",
+      branch = "main",
       after = "nvim-web-devicons",
       config = function()
         require("configs.bufferline").config()
@@ -306,6 +307,7 @@ if packer_status_ok then
     {
       "akinsho/nvim-toggleterm.lua",
       cmd = "ToggleTerm",
+      branch = "main",
       module = { "toggleterm", "toggleterm.terminal" },
       config = function()
         require("configs.toggleterm").config()


### PR DESCRIPTION
When installing the latest AstroNvim against a fresh installation of neovim 0.7 - there is an issue with the initial PackerSync.

Two plugins, BufferLine and ToggleTerm, have changed from using "master" to "main" as their default branch. This PR specifies to use the "main" branch for these two plugins.