### PR TITLE
Telescope whichkey fix

### DIFF
--- a/lua/configs/which-key.lua
+++ b/lua/configs/which-key.lua
@@ -3,6 +3,14 @@ local M = {}
 function M.config()
   local status_ok, which_key = pcall(require, "which-key")
   if status_ok then
+    -- Don't show which-key popup when Telescope is opened
+    local show = which_key.show
+    which_key.show = function(keys, opts)
+      if vim.bo.filetype == "TelescopePrompt" then
+        return
+      end
+      show(keys, opts)
+    end
     which_key.setup(require("core.utils").user_plugin_opts("plugins.which-key", {
       plugins = {
         spelling = { enabled = true },

--- a/lua/configs/which-key.lua
+++ b/lua/configs/which-key.lua
@@ -3,13 +3,16 @@ local M = {}
 function M.config()
   local status_ok, which_key = pcall(require, "which-key")
   if status_ok then
-    -- Don't show which-key popup when Telescope is opened
     local show = which_key.show
-    which_key.show = function(keys, opts)
-      if vim.bo.filetype == "TelescopePrompt" then
-        return
+    local show_override = require("core.utils").user_plugin_opts("which-key.show", nil, false)
+    if type(show_override) == "function" then
+      which_key.show = show_override(show)
+    else
+      which_key.show = function(keys, opts)
+        if vim.bo.filetype ~= "TelescopePrompt" then
+          show(keys, opts)
+        end
       end
-      show(keys, opts)
     end
     which_key.setup(require("core.utils").user_plugin_opts("plugins.which-key", {
       plugins = {


### PR DESCRIPTION
Thanks @thieung for catching this issue and contributing the initial fix for which-key breaking telescope's normal mode. This adds a small extension to allow the user to override this function if they have different needs or conflicts with other plugins as well.

Extension of #491 