### PR TITLE
BREAKING: Treat null-ls like every other plugin

### DIFF
--- a/lua/configs/autopairs.lua
+++ b/lua/configs/autopairs.lua
@@ -24,7 +24,7 @@ function M.config()
       },
     }))
 
-    local rules = require("core.utils").user_plugin_opts("nvim-autopairs", {}).add_rules
+    local rules = require("core.utils").user_plugin_opts("nvim-autopairs").add_rules
     if vim.tbl_contains({ "function", "table" }, type(rules)) then
       npairs.add_rules(type(rules) == "function" and rules(npairs) or rules)
     end

--- a/lua/configs/better_escape.lua
+++ b/lua/configs/better_escape.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.config()
   local present, better_escape = pcall(require, "better_escape")
   if present then
-    better_escape.setup(require("core.utils").user_plugin_opts("plugins.better_escape", {}))
+    better_escape.setup(require("core.utils").user_plugin_opts "plugins.better_escape")
   end
 end
 

--- a/lua/configs/indent-o-matic.lua
+++ b/lua/configs/indent-o-matic.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.config()
   local present, indent_o_matic = pcall(require, "indent-o-matic")
   if present then
-    indent_o_matic.setup(require("core.utils").user_plugin_opts("plugins.indent-o-matic", {}))
+    indent_o_matic.setup(require("core.utils").user_plugin_opts "plugins.indent-o-matic")
   end
 end
 

--- a/lua/configs/lsp/init.lua
+++ b/lua/configs/lsp/init.lua
@@ -5,7 +5,7 @@ if status_ok then
   local handlers = require "configs.lsp.handlers"
   handlers.setup()
 
-  local servers = user_plugin_opts("lsp.servers", {})
+  local servers = user_plugin_opts "lsp.servers"
   local installer_avail, lsp_installer = pcall(require, "nvim-lsp-installer")
   if installer_avail then
     for _, server in ipairs(lsp_installer.get_installed_servers()) do

--- a/lua/configs/luasnip.lua
+++ b/lua/configs/luasnip.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.config()
-  local user_settings = require("core.utils").user_plugin_opts("luasnip", {})
+  local user_settings = require("core.utils").user_plugin_opts "luasnip"
   local loader_avail, loader = pcall(require, "luasnip/loaders/from_vscode")
   if loader_avail then
     if user_settings.vscode_snippet_paths ~= nil then

--- a/lua/configs/notify.lua
+++ b/lua/configs/notify.lua
@@ -3,9 +3,7 @@ local M = {}
 function M.config()
   local present, notify = pcall(require, "notify")
   if present then
-    notify.setup(require("core.utils").user_plugin_opts("plugins.notify", {
-      stages = "fade",
-    }))
+    notify.setup(require("core.utils").user_plugin_opts("plugins.notify", { stages = "fade" }))
 
     vim.notify = notify
   end

--- a/lua/configs/null-ls.lua
+++ b/lua/configs/null-ls.lua
@@ -1,0 +1,10 @@
+local M = {}
+
+function M.config()
+  local present, null_ls = pcall(require, "null-ls")
+  if present then
+    null_ls.setup(require("core.utils").user_plugin_opts "plugins.null-ls")
+  end
+end
+
+return M

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -216,10 +216,7 @@ if packer_status_ok then
       "jose-elias-alvarez/null-ls.nvim",
       event = { "BufRead", "BufNewFile" },
       config = function()
-        local null_ls = require("core.utils").user_plugin_opts("null-ls", nil, false)
-        if type(null_ls) == "function" then
-          null_ls()
-        end
+        require("configs.null-ls").config()
       end,
     },
 

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -86,6 +86,7 @@ function M.user_plugin_opts(module, default, extend)
   if extend == nil then
     extend = true
   end
+  default = default or {}
   local user_settings = load_module_file("user." .. module)
   if user_settings == nil then
     user_settings = user_setting_table(module)

--- a/lua/default_theme/utils.lua
+++ b/lua/default_theme/utils.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local user_settings = require("core.utils").user_plugin_opts("default_theme", {})
+local user_settings = require("core.utils").user_plugin_opts "default_theme"
 
 function M.parse_diagnostic_style(default)
   if type(user_settings.diagnostics_style) == "table" then

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -53,6 +53,30 @@ local config = {
       -- },
     },
     -- All other entries override the setup() call for default plugins
+    ["null-ls"] = function(config)
+      local null_ls = require "null-ls"
+      -- Check supported formatters and linters
+      -- https://github.com/jose-elias-alvarez/null-ls.nvim/tree/main/lua/null-ls/builtins/formatting
+      -- https://github.com/jose-elias-alvarez/null-ls.nvim/tree/main/lua/null-ls/builtins/diagnostics
+      config.sources = {
+        -- Set a formatter
+        null_ls.formatting.rufo,
+        -- Set a linter
+        null_ls.diagnostics.rubocop,
+      }
+      -- set up null-ls's on_attach function
+      config.on_attach = function(client)
+        -- NOTE: You can remove this on attach function to disable format on save
+        if client.resolved_capabilities.document_formatting then
+          vim.api.nvim_create_autocmd("BufWritePre", {
+            desc = "Auto format before save",
+            pattern = "<buffer>",
+            callback = vim.lsp.buf.formatting_sync,
+          })
+        end
+      end
+      return config -- return final config table
+    end,
     treesitter = {
       ensure_installed = { "lua" },
     },
@@ -141,44 +165,6 @@ local config = {
     virtual_text = true,
     underline = true,
   },
-
-  -- null-ls configuration
-  ["null-ls"] = function()
-    -- Formatting and linting
-    -- https://github.com/jose-elias-alvarez/null-ls.nvim
-    local status_ok, null_ls = pcall(require, "null-ls")
-    if not status_ok then
-      return
-    end
-
-    -- Check supported formatters
-    -- https://github.com/jose-elias-alvarez/null-ls.nvim/tree/main/lua/null-ls/builtins/formatting
-    local formatting = null_ls.builtins.formatting
-
-    -- Check supported linters
-    -- https://github.com/jose-elias-alvarez/null-ls.nvim/tree/main/lua/null-ls/builtins/diagnostics
-    local diagnostics = null_ls.builtins.diagnostics
-
-    null_ls.setup {
-      debug = false,
-      sources = {
-        -- Set a formatter
-        formatting.rufo,
-        -- Set a linter
-        diagnostics.rubocop,
-      },
-      -- NOTE: You can remove this on attach function to disable format on save
-      on_attach = function(client)
-        if client.resolved_capabilities.document_formatting then
-          vim.api.nvim_create_autocmd("BufWritePre", {
-            desc = "Auto format before save",
-            pattern = "<buffer>",
-            callback = vim.lsp.buf.formatting_sync,
-          })
-        end
-      end,
-    }
-  end,
 
   -- This function is run last
   -- good place to configure mappings and vim options


### PR DESCRIPTION
Right now we have a very specific set up for `null-ls`. This makes it treated like every other plugin.