### PR TITLE
chore: disable omnifunc

### DIFF
--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -67,7 +67,6 @@ M.on_attach = function(client, bufnr)
   vim.keymap.set("n", "gk", vim.diagnostic.goto_prev, { desc = "Go to previous diagnostic", buffer = 0 })
   vim.keymap.set("n", "gl", vim.diagnostic.open_float, { desc = "Hover diagnostics", buffer = 0 })
   vim.keymap.set("n", "go", vim.diagnostic.open_float, { desc = "Hover diagnostics", buffer = 0 })
-  vim.api.nvim_buf_set_option(0, "omnifunc", "v:lua.vim.lsp.omnifunc")
   vim.api.nvim_create_user_command("Format", vim.lsp.buf.formatting, { desc = "Format file with LSP" })
 
   if client.name == "tsserver" or client.name == "jsonls" or client.name == "html" or client.name == "sumneko_lua" then


### PR DESCRIPTION
[nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/wiki/Autocompletion#nvim-cmp) mentioned that we don't need to use omnifunc since  we are using `nvim-cmp`
> If you are using nvim-cmp do not use neovim's built-in omnifunc as it cannot support the additional completion items returned from servers due to the capabilities enabled by nvim-cmp.