### PR TITLE
feat(cmp): add user config for extension cmp setup calls

### DIFF
--- a/lua/configs/cmp.lua
+++ b/lua/configs/cmp.lua
@@ -4,6 +4,7 @@ function M.config()
   local cmp_status_ok, cmp = pcall(require, "cmp")
   local snip_status_ok, luasnip = pcall(require, "luasnip")
   if cmp_status_ok and snip_status_ok then
+    local setup = cmp.setup
     local kind_icons = {
       Text = "",
       Method = "",
@@ -37,7 +38,7 @@ function M.config()
       return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match "%s" == nil
     end
 
-    cmp.setup(astronvim.user_plugin_opts("plugins.cmp", {
+    setup(astronvim.user_plugin_opts("plugins.cmp", {
       preselect = cmp.PreselectMode.None,
       formatting = {
         fields = { "kind", "abbr", "menu" },
@@ -113,6 +114,11 @@ function M.config()
         }),
       },
     }))
+    for setup_opt, setup_table in pairs(astronvim.user_plugin_opts("cmp.setup", {})) do
+      for pattern, options in pairs(setup_table) do
+        setup[setup_opt](pattern, options)
+      end
+    end
   end
 end
 

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -148,7 +148,7 @@ function astronvim.add_cmp_source(source)
   end
 end
 
-function astronvim.add_user_cmp_source(source)
+function astronvim.get_user_cmp_source(source)
   source = type(source) == "string" and { name = source } or source
   local priority = astronvim.user_plugin_opts("cmp.source_priority", {
     nvim_lsp = 1000,
@@ -159,7 +159,11 @@ function astronvim.add_user_cmp_source(source)
   if priority then
     source.priority = priority
   end
-  astronvim.add_cmp_source(source)
+  return source
+end
+
+function astronvim.add_user_cmp_source(source)
+  astronvim.add_cmp_source(astronvim.get_user_cmp_source(source))
 end
 
 function astronvim.null_ls_providers(filetype)


### PR DESCRIPTION
This allows the user to call the other `cmp.setup.X` calls with a simple table in the `user/init.lua` file. An example of an in depth setup for this is:

```lua
local buffer_source = {
  name = "buffer",
  option = {
    get_bufnrs = function()
      local bufs = {}
      for _, win in ipairs(vim.api.nvim_list_wins()) do
        bufs[vim.api.nvim_win_get_buf(win)] = true
      end
      return vim.tbl_keys(bufs)
    end,
  },
}

return {
  plugins = {
    init = {
      ["hrsh7th/cmp-buffer"] = {
        config = function()
          astronvim.add_user_cmp_source(buffer_source)
        end,
      },
    },
  },
  cmp = {
    source_priority = {
      luasnip = 1000,
      nvim_lsp = 750,
      nvim_lsp_signature_help = 700,
      pandoc_references = 600,
      buffer = 500,
      path = 250,
      emoji = 200,
      dictionary = 150,
    },
    setup = function()
      local cmp = require "cmp"
      local user_source = astronvim.get_user_source
      local git_sources = cmp.config.sources({ user_source "cmp_git" }, { user_source(buffer_source) })
      return {
        filetype = {
          gitcommit = { sources = git_sources },
          NeogitCommit = { sources = git_sources },
          lua = {
            sources = {
              user_source "lsp",
            },
          },
        },
        cmd = {
          [":"] = {
            mapping = cmp.mapping.preset.cmdline(),
            sources = cmp.config.sources({
              user_source "path",
            }, {
              user_source "cmd",
            }),
          },
        },
      }
    end,
  },
}
```