### PR TITLE
chore(gitignore): drop trailing slash from lua/user path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 plugin
-lua/user/
+lua/user
 lua/packer_compiled.lua


### PR DESCRIPTION
I use symlinks a lot to manage my configuration files and apparently, a trailing slash does not match a symlink to a directory, I hope it is ok to make this little change

And thank you for this configuration, absolutely loving it so far!