### PR TITLE
fix: call function setup instead of config for feline package

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -82,7 +82,7 @@ local astro_plugins = {
   -- Statusline
   ["feline-nvim/feline.nvim"] = {
     after = "nvim-web-devicons",
-    config = function()
+    setup = function()
       require("configs.feline").config()
     end,
   },


### PR DESCRIPTION
Resolves #555 

After the latest update, the feline package requires calling the `setup` function, not `config` in the initialization section.