### PR TITLE
fix(status): remove lsp_client_name bug in feline

### DIFF
--- a/lua/core/status.lua
+++ b/lua/core/status.lua
@@ -78,7 +78,7 @@ end
 function M.provider.lsp_client_names(expand_null_ls)
   return function()
     local buf_client_names = {}
-    for _, client in ipairs(vim.lsp.buf_get_clients(0)) do
+    for _, client in pairs(vim.lsp.buf_get_clients(0)) do
       if client.name == "null-ls" and expand_null_ls then
         vim.list_extend(buf_client_names, astronvim.null_ls_sources(vim.bo.filetype, "FORMATTING"))
         vim.list_extend(buf_client_names, astronvim.null_ls_sources(vim.bo.filetype, "DIAGNOSTICS"))


### PR DESCRIPTION
I notice one problem that if you open a random file, the lsp_clients_name will display properly but if you open another file on another directory, lsp_clients_name won't exist on that file.