### PR TITLE
chore(bufferline): make selected buffer noticeable in bufferline

### DIFF
--- a/lua/default_theme/plugins/bufferline.lua
+++ b/lua/default_theme/plugins/bufferline.lua
@@ -2,7 +2,7 @@ return {
   BufferLineFill = { fg = C.grey_9, bg = C.grey_4 },
   BufferLineBackground = { fg = C.grey_9, bg = C.grey_4 },
   BufferLineBufferVisible = { fg = C.fg, bg = C.bg },
-  BufferLineBufferSelected = { fg = C.fg, bg = C.bg },
+  BufferLineBufferSelected = { fg = C.white, bg = C.bg, bold = true },
   BufferLineTab = { fg = C.grey_9, bg = C.bg },
   BufferLineTabSelected = { fg = C.fg, bg = C.bg },
   BufferLineTabClose = { fg = C.red_4, bg = C.bg },


### PR DESCRIPTION
Makes the currently selected buffer noticeable in the tab line. Useful when there are several visible buffers with splits.

![2022-05-26_14:48:21_screenshot](https://user-images.githubusercontent.com/1591837/170556628-6c21654e-2110-4ab7-a167-f768a2619ff6.png)
