### PR TITLE
feat(lsp): add ability to skip lsp setup for a server

### DIFF
--- a/lua/configs/lsp/init.lua
+++ b/lua/configs/lsp/init.lua
@@ -2,6 +2,7 @@ local status_ok, lspconfig = pcall(require, "lspconfig")
 if status_ok then
   local insert = table.insert
   local tbl_deep_extend = vim.tbl_deep_extend
+  local tbl_contains = vim.tbl_contains
   local user_plugin_opts = astronvim.user_plugin_opts
   local user_registration = user_plugin_opts("lsp.server_registration", nil, false)
   local handlers = require "configs.lsp.handlers"
@@ -9,6 +10,7 @@ if status_ok then
   handlers.setup()
 
   local servers = user_plugin_opts "lsp.servers"
+  local skip_setup = user_plugin_opts "lsp.skip_setup"
   local installer_avail, lsp_installer = pcall(require, "nvim-lsp-installer")
   if installer_avail then
     for _, server in ipairs(lsp_installer.get_installed_servers()) do
@@ -16,26 +18,28 @@ if status_ok then
     end
   end
   for _, server in ipairs(servers) do
-    local old_on_attach = lspconfig[server].on_attach
-    local opts = {
-      on_attach = function(client, bufnr)
-        if old_on_attach then
-          old_on_attach(client, bufnr)
-        end
-        on_attach(client, bufnr)
-      end,
-      capabilities = tbl_deep_extend("force", handlers.capabilities, lspconfig[server].capabilities or {}),
-    }
-    local present, av_overrides = pcall(require, "configs.lsp.server-settings." .. server)
-    if present then
-      opts = tbl_deep_extend("force", av_overrides, opts)
-    end
-    opts = user_plugin_opts("lsp.server-settings." .. server, opts)
+    if not tbl_contains(skip_setup, server) then
+      local old_on_attach = lspconfig[server].on_attach
+      local opts = {
+        on_attach = function(client, bufnr)
+          if old_on_attach then
+            old_on_attach(client, bufnr)
+          end
+          on_attach(client, bufnr)
+        end,
+        capabilities = tbl_deep_extend("force", handlers.capabilities, lspconfig[server].capabilities or {}),
+      }
+      local present, av_overrides = pcall(require, "configs.lsp.server-settings." .. server)
+      if present then
+        opts = tbl_deep_extend("force", av_overrides, opts)
+      end
+      opts = user_plugin_opts("lsp.server-settings." .. server, opts)
 
-    if type(user_registration) == "function" then
-      user_registration(server, opts)
-    else
-      lspconfig[server].setup(opts)
+      if type(user_registration) == "function" then
+        user_registration(server, opts)
+      else
+        lspconfig[server].setup(opts)
+      end
     end
   end
 end


### PR DESCRIPTION
Some users may want to use plugins for setting up language servers such as https://github.com/p00f/clangd_extensions.nvim or https://github.com/jose-elias-alvarez/typescript.nvim which requires you to not call the `require("lspconfig")[server_name].setup` call. This adds a nice user configuration for telling AstroNvim to not worry about setting up a server even if it is available.