### PR TITLE
feat(core): add AstroVersion command to check version

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -99,4 +99,5 @@ if is_available "feline.nvim" then
 end
 
 create_command("AstroUpdate", astronvim.update, { desc = "Update AstroNvim" })
+create_command("AstroVersion", astronvim.version, { desc = "Check AstroNvim Version" })
 create_command("ToggleHighlightURL", astronvim.toggle_url_match, { desc = "Toggle URL Highlights" })

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -254,5 +254,21 @@ function astronvim.update()
     })
     :sync()
 end
+function astronvim.version()
+  (require "plenary.job")
+    :new({
+      command = "git",
+      args = { "describe", "--tags" },
+      cwd = stdpath "config",
+      on_exit = function(out, return_val)
+        if return_val == 0 then
+          vim.notify("Version: " .. out:result()[1], "info", astronvim.base_notification)
+        else
+          vim.notify("Error retrieving version", "error", astronvim.base_notification)
+        end
+      end,
+    })
+    :start()
+end
 
 return astronvim


### PR DESCRIPTION
This adds the command `:AstroVersion` which displays the latest tag and the current commit hash.

Resolves #584 