### PR TITLE
feat(lsp): allow user defined per lsp on_attach additions

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -20,7 +20,4 @@ for _, source in ipairs {
   end
 end
 
-local polish = astronvim.user_plugin_opts("polish", nil, false)
-if type(polish) == "function" then
-  polish()
-end
+astronvim.conditional_func(astronvim.user_plugin_opts("polish", nil, false))

--- a/lua/configs/Comment.lua
+++ b/lua/configs/Comment.lua
@@ -3,19 +3,18 @@ local M = {}
 function M.config()
   local status_ok, Comment = pcall(require, "Comment")
   if status_ok then
+    local utils = require "Comment.utils"
     Comment.setup(astronvim.user_plugin_opts("plugins.Comment", {
       pre_hook = function(ctx)
-        local U = require "Comment.utils"
-
         local location = nil
-        if ctx.ctype == U.ctype.block then
+        if ctx.ctype == utils.ctype.block then
           location = require("ts_context_commentstring.utils").get_cursor_location()
-        elseif ctx.cmotion == U.cmotion.v or ctx.cmotion == U.cmotion.V then
+        elseif ctx.cmotion == utils.cmotion.v or ctx.cmotion == utils.cmotion.V then
           location = require("ts_context_commentstring.utils").get_visual_start_location()
         end
 
         return require("ts_context_commentstring.internal").calculate_commentstring {
-          key = ctx.ctype == U.ctype.line and "__default" or "__multiline",
+          key = ctx.ctype == utils.ctype.line and "__default" or "__multiline",
           location = location,
         }
       end,

--- a/lua/configs/lsp/server-settings/html.lua
+++ b/lua/configs/lsp/server-settings/html.lua
@@ -1,0 +1,1 @@
+return { on_attach = astronvim.lsp.disable_formatting }

--- a/lua/configs/lsp/server-settings/jsonls.lua
+++ b/lua/configs/lsp/server-settings/jsonls.lua
@@ -1,4 +1,5 @@
 return {
+  on_attach = astronvim.lsp.disable_formatting,
   settings = {
     json = {
       schemas = require("schemastore").json.schemas(),

--- a/lua/configs/lsp/server-settings/sumneko_lua.lua
+++ b/lua/configs/lsp/server-settings/sumneko_lua.lua
@@ -1,4 +1,5 @@
 return {
+  on_attach = astronvim.lsp.disable_formatting,
   settings = {
     Lua = {
       diagnostics = {

--- a/lua/configs/lsp/server-settings/tsserver.lua
+++ b/lua/configs/lsp/server-settings/tsserver.lua
@@ -1,0 +1,1 @@
+return { on_attach = astronvim.lsp.disable_formatting }

--- a/lua/configs/telescope.lua
+++ b/lua/configs/telescope.lua
@@ -5,14 +5,8 @@ function M.config()
   if status_ok then
     local actions = require "telescope.actions"
 
-    local notify_present, _ = pcall(require, "notify")
-    if notify_present then
-      telescope.load_extension "notify"
-    end
-    local aerial_present, _ = pcall(require, "aerial")
-    if aerial_present then
-      telescope.load_extension "aerial"
-    end
+    astronvim.conditional_func(telescope.load_extension, pcall(require, "notify"), "notify")
+    astronvim.conditional_func(telescope.load_extension, pcall(require, "aerial"), "aerial")
 
     telescope.setup(astronvim.user_plugin_opts("plugins.telescope", {
       defaults = {

--- a/lua/configs/treesitter.lua
+++ b/lua/configs/treesitter.lua
@@ -15,24 +15,16 @@ function M.config()
         enable = true,
         enable_autocmd = false,
       },
-      autopairs = {
-        enable = true,
-      },
-      incremental_selection = {
-        enable = true,
-      },
-      indent = {
-        enable = false,
-      },
       rainbow = {
         enable = true,
         disable = { "html" },
         extended_mode = false,
         max_file_lines = nil,
       },
-      autotag = {
-        enable = true,
-      },
+      autopairs = { enable = true },
+      autotag = { enable = true },
+      incremental_selection = { enable = true },
+      indent = { enable = false },
     }))
   end
 end

--- a/lua/configs/which-key.lua
+++ b/lua/configs/which-key.lua
@@ -6,15 +6,12 @@ function M.config()
   if status_ok then
     local show = which_key.show
     local show_override = user_plugin_opts("which-key.show", nil, false)
-    if type(show_override) == "function" then
-      which_key.show = show_override(show)
-    else
-      which_key.show = function(keys, opts)
+    which_key.show = type(show_override) == "function" and show_override(show)
+      or function(keys, opts)
         if vim.bo.filetype ~= "TelescopePrompt" then
           show(keys, opts)
         end
       end
-    end
     which_key.setup(user_plugin_opts("plugins.which-key", {
       plugins = {
         spelling = { enabled = true },

--- a/lua/core/ui.lua
+++ b/lua/core/ui.lua
@@ -139,7 +139,5 @@ function ui.telescope_select()
 end
 
 for ui_addition, enabled in pairs(astronvim.user_plugin_opts("ui", { nui_input = true, telescope_select = true })) do
-  if enabled and type(ui[ui_addition]) == "function" then
-    ui[ui_addition]()
-  end
+  astronvim.conditional_func(ui[ui_addition], enabled)
 end

--- a/lua/core/utils.lua
+++ b/lua/core/utils.lua
@@ -44,6 +44,12 @@ local function func_or_extend(overrides, default, extend)
   return default
 end
 
+function astronvim.conditional_func(func, condition, ...)
+  if (condition == nil and true or condition) and type(func) == "function" then
+    return func(...)
+  end
+end
+
 local function user_setting_table(module)
   local settings = astronvim.user_settings or {}
   for tbl in string.gmatch(module, "([^%.]+)") do
@@ -86,13 +92,13 @@ function astronvim.vim_opts(options)
   end
 end
 
-function astronvim.user_plugin_opts(module, default, extend)
+function astronvim.user_plugin_opts(module, default, extend, prefix)
   if extend == nil then
     extend = true
   end
   default = default or {}
-  local user_settings = load_module_file("user." .. module)
-  if user_settings == nil then
+  local user_settings = load_module_file((prefix or "user") .. "." .. module)
+  if user_settings == nil and prefix == nil then
     user_settings = user_setting_table(module)
   end
   if user_settings ~= nil then
@@ -254,6 +260,7 @@ function astronvim.update()
     })
     :sync()
 end
+
 function astronvim.version()
   (require "plenary.job")
     :new({


### PR DESCRIPTION
This allows additions to the `on_attach` function for specific language servers in the `lsp.server-settings` table. This was completely incorrectly handled and honestly could be considered just a flat out bug until now. For example, disabling formatting for a single language server can now look like this:

```lua
return {
  lsp = {
    ["server-settings"] = {
      html = {
        on_attach = function(client, bufnr)
          client.resolved_capabilities.document_formatting = false
        end
      }
    }
  }
}
```

Also makes it easier to disable our custom `on_attach` for specific languages, like if a user wants to use `tsserver` formatting they can just do this:

```lua
return {
  lsp = {
    ["server-settings"] = {
      tsserver = {
        on_attach = function() end
      }
    }
  }
}
```