### PR TITLE
chore: load lsp utils with all other utils

### DIFF
--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -1,3 +1,4 @@
+-- TODO: Move this to utils/lsp.lua with v2.0.0
 astronvim.lsp = {}
 local map = vim.keymap.set
 local user_plugin_opts = astronvim.user_plugin_opts

--- a/lua/configs/lsp/init.lua
+++ b/lua/configs/lsp/init.lua
@@ -1,6 +1,5 @@
 local status_ok, lspconfig = pcall(require, "lspconfig")
 if status_ok then
-  require "configs.lsp.handlers"
   local insert = table.insert
   local tbl_contains = vim.tbl_contains
   local sign_define = vim.fn.sign_define

--- a/lua/core/utils/init.lua
+++ b/lua/core/utils/init.lua
@@ -276,5 +276,6 @@ function astronvim.cmd(cmd, show_error)
 end
 
 require "core.utils.updater"
+require "configs.lsp.handlers"
 
 return astronvim


### PR DESCRIPTION
This loads our `lsp` utility functions to be loading with the rest of the utility functions. We need to move the file entirely to `core/utils/lsp.lua` but this would be considered a breaking change if people are `require`ing the file manually. So we will move it in v2.0.0 release