### PR TITLE
config: Increase aerial disable_max_lines

### DIFF
--- a/lua/configs/aerial.lua
+++ b/lua/configs/aerial.lua
@@ -6,6 +6,7 @@ if status_ok then
     min_width = 28,
     show_guides = true,
     filter_kind = false,
+    disable_max_lines = 30000,
     icons = {
       Array = "",
       Boolean = "⊨",


### PR DESCRIPTION
First, thank you AstroNvim is really cool.

This MR increases disable_max_lines to support symbols outline and search in large files.
Symbols search and outline were not possible with large python files, which is helpful with such kinds of files (that need to be split).
The default seems to be 10k lines, and this MR proposed to increase to 30k.
Performance is good even with files near 30k lines.



