### PR TITLE
fix(core): Set colorscheme after opts

### DIFF
--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -1,9 +1,3 @@
-local colorscheme = astronvim.user_plugin_opts("colorscheme", nil, false)
-vim.api.nvim_command(
-  "colorscheme "
-    .. (vim.tbl_contains(vim.fn.getcompletion("", "color"), colorscheme) and colorscheme or "default_theme")
-)
-
 astronvim.vim_opts(astronvim.user_plugin_opts("options", {
   opt = {
     backspace = vim.opt.backspace + { "nostop" }, -- Don't stop backspace at insert
@@ -65,3 +59,9 @@ astronvim.vim_opts(astronvim.user_plugin_opts("options", {
     loaded_vimballPlugin = true, -- disable vimball
   },
 }))
+
+local colorscheme = astronvim.user_plugin_opts("colorscheme", nil, false)
+vim.api.nvim_command(
+  "colorscheme "
+    .. (vim.tbl_contains(vim.fn.getcompletion("", "color"), colorscheme) and colorscheme or "default_theme")
+)


### PR DESCRIPTION
Some colorschemes which have multiple style options like:
- [marko-cerovac/material.nvim](https://github.com/marko-cerovac/material.nvim.git)
- [folke/tokyonight.nvim](https://github.com/folke/tokyonight.nvim)

Require their options to be set before setting up or enabling the colorscheme

---
So when I add the colorscheme plugin, and set it up like the following:
```lua
  -- Set colorscheme
| colorscheme = "tokyonight",

  -- set vim options here (vim.<first_key>.<second_key> =  value)
  options = {
    ...
    g = {
|     tokyonight_style = "night",
    },
  },

  ...

  -- Configure plugins
  plugins = {
    -- Add plugins, the packer syntax without the "use"
    init = {
|     { "folke/tokyonight.nvim" },
      ...
    },
    ...
},
```

Each time I open nvim the default style option is loaded, and I need to run `:colorscheme tokyonight` to load the `tokyonight_style = "night"` style option

---

Correct me if I'm doing it wrong or if I'm missing something, but I moved these lines which set up the colorscheme in `lua/core/options.lua` 

```lua
local colorscheme = astronvim.user_plugin_opts("colorscheme", nil, false)
vim.api.nvim_command(
  "colorscheme "
    .. (vim.tbl_contains(vim.fn.getcompletion("", "color"), colorscheme) and colorscheme or "default_theme")
)
```
to the end of the file, so the colorscheme is being set after the options

and this solves the issue