### PR TITLE
feat: enable external package manager installations of astronvim

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,6 +2,7 @@
 globals = {
   "PACKER_BOOTSTRAP",
   "astronvim",
+  "astronvim_installation",
   "vim",
   "C",
   "packer_plugins",

--- a/init.lua
+++ b/init.lua
@@ -3,8 +3,6 @@ if impatient_ok then
   impatient.enable_profile()
 end
 
-vim.opt.rtp:append(vim.fn.stdpath "config" .. "/../astronvim")
-
 for _, source in ipairs {
   "core.utils",
   "core.options",

--- a/lua/configs/lsp/server-settings/sumneko_lua.lua
+++ b/lua/configs/lsp/server-settings/sumneko_lua.lua
@@ -8,7 +8,7 @@ return {
       workspace = {
         library = {
           [vim.fn.expand "$VIMRUNTIME/lua"] = true,
-          [vim.fn.stdpath "config" .. "/lua"] = true,
+          [astronvim.install.home .. "/lua"] = true,
         },
       },
     },

--- a/lua/core/utils/git.lua
+++ b/lua/core/utils/git.lua
@@ -1,7 +1,11 @@
 local git = { url = "https://github.com/" }
 
 function git.cmd(args, ...)
-  return astronvim.cmd("git -C " .. vim.fn.stdpath "config" .. " " .. args, ...)
+  return astronvim.cmd("git -C " .. astronvim.install.home .. " " .. args, ...)
+end
+
+function git.is_repo()
+  return git.cmd("rev-parse --is-inside-work-tree", false)
 end
 
 function git.fetch(remote, ...)

--- a/lua/core/utils/init.lua
+++ b/lua/core/utils/init.lua
@@ -2,10 +2,13 @@ _G.astronvim = {}
 local stdpath = vim.fn.stdpath
 local tbl_insert = table.insert
 
-local supported_configs = {
-  stdpath "config",
-  stdpath "config" .. "/../astronvim",
-}
+local path_avail, path = pcall(require, "plenary/path")
+local astronvim_config = nil
+if path_avail then
+  astronvim_config = path:new(vim.fn.stdpath "config"):parent() .. "/astronvim"
+  vim.opt.rtp:append(astronvim_config)
+end
+local supported_configs = { stdpath "config", astronvim_config }
 
 local function load_module_file(module)
   local found_module = nil
@@ -27,7 +30,7 @@ local function load_module_file(module)
 end
 
 astronvim.user_settings = load_module_file "user.init"
-astronvim.default_compile_path = stdpath "config" .. "/lua/packer_compiled.lua"
+astronvim.default_compile_path = stdpath "data" .. "/packer_compiled.lua"
 astronvim.user_terminals = {}
 astronvim.url_matcher =
   "\\v\\c%(%(h?ttps?|ftp|file|ssh|git)://|[a-z]+[@][a-z]+[.][a-z]+:)%([&:#*@~%_\\-=?!+;/0-9a-z]+%(%([.;/?]|[.][.]+)[&:#*@~%_\\-=?!+/0-9a-z]+|:\\d+|,%(%(%(h?ttps?|ftp|file|ssh|git)://|[a-z]+[@][a-z]+[.][a-z]+:)@![0-9a-z]+))*|\\([&:#*@~%_\\-=?!+;/.0-9a-z]*\\)|\\[[&:#*@~%_\\-=?!+;/.0-9a-z]*\\]|\\{%([&:#*@~%_\\-=?!+;/.0-9a-z]*|\\{[&:#*@~%_\\-=?!+;/.0-9a-z]*})\\})+"

--- a/lua/core/utils/init.lua
+++ b/lua/core/utils/init.lua
@@ -2,13 +2,15 @@ _G.astronvim = {}
 local stdpath = vim.fn.stdpath
 local tbl_insert = table.insert
 
+astronvim.install = astronvim_installation or { home = stdpath "config" }
+
 local path_avail, path = pcall(require, "plenary/path")
 local astronvim_config = nil
 if path_avail then
-  astronvim_config = path:new(vim.fn.stdpath "config"):parent() .. "/astronvim"
+  astronvim_config = path:new(stdpath "config"):parent() .. "/astronvim"
   vim.opt.rtp:append(astronvim_config)
 end
-local supported_configs = { stdpath "config", astronvim_config }
+local supported_configs = { astronvim.install.home, astronvim_config }
 
 local function load_module_file(module)
   local found_module = nil

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -120,7 +120,7 @@ local config = {
       ensure_installed = { "sumneko_lua" },
     },
     packer = {
-      compile_path = vim.fn.stdpath "config" .. "/lua/packer_compiled.lua",
+      compile_path = vim.fn.stdpath "data" .. "/packer_compiled.lua",
     },
   },
 


### PR DESCRIPTION
This moves the default packer compiled location the the data folder since it's not a config file. This also enables the ability for AstroNvim to easily be loaded in a non-git manner. Say with a package manager and disables the Updater.

Package managers need to set a global variable in Neovim when setting up the `runtimepath` that adds the new installation location. The variable is as follows:

```lua
_G.astronvim_installation = {
  home = "<installation_runetime_path>",
  version = "<installed_version_string>",
  is_stable = true, -- boolean value of whether or not it's stable
}
```

Here is an example `astronvim.vim` that would be placed in `/usr/share/nvim/runtime/plugin/astronvim.vim` to autoload a nightly installation of `AstroNvim` installed to `/usr/share/astronvim`:

```vim
lua _G.astronvim_installation={home='/usr/share/astronvim', version='1.4.4.g416736f', is_stable=false}
set runtimepath+=/usr/share/astronvim
luafile /usr/share/astronvim/init.lua
```