### PR TITLE
docs: point to full list of supported clipboard tools

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -49,7 +49,7 @@ AstroNvim is an aesthetic and feature-rich neovim config that is extensible and 
 
 - [Nerd Fonts](https://www.nerdfonts.com/font-downloads)
 - [Neovim 0.7+](https://github.com/neovim/neovim/releases/tag/v0.7.0)
-- [xclip](https://github.com/astrand/xclip) - (Linux only) xclip is necessary for the clipboard integration with the system clipboard
+- A clipboard tool is necessary for the integration with the system clipboard (see [`:help clipboard-tool`](https://neovim.io/doc/user/provider.html#clipboard-tool) for supported solutions)
 - Terminal with true color support (for the default theme, otherwise it is dependent on the theme you are using)
 - Optional Requirements:
   - [ripgrep](https://github.com/BurntSushi/ripgrep) - live grep telescope search (`<leader>fw`)


### PR DESCRIPTION
I spotted that in the latest release

`xclip` is for X11, `wl-clipboard` is for Wayland, and there actually are others:

```
                                                              clipboard-tool
The presence of a working clipboard tool implicitly enables the '+' and '*'
registers. Nvim looks for these clipboard tools, in order of priority:

  - g:clipboard
  - pbcopy, pbpaste (macOS)
  - wl-copy, wl-paste (if $WAYLAND_DISPLAY is set)
  - xclip (if $DISPLAY is set)
  - xsel (if $DISPLAY is set)
  - lemonade (for SSH) https://github.com/pocke/lemonade
  - doitclient (for SSH) http://www.chiark.greenend.org.uk/~sgtatham/doit/
  - win32yank (Windows)
  - termux (via termux-clipboard-set, termux-clipboard-set)
  - tmux (if $TMUX is set)
```

https://neovim.io/doc/user/provider.html#clipboard-tool

Windows does not seem to come with a pre-installed one either.

And as always, thank you for AstroNvim! :heart: