### PR TITLE
Buffer closing vs buffer wipte

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -42,7 +42,7 @@ end
 if is_available "bufdelete.nvim" then
   maps.n["<leader>c"] = { "<cmd>Bdelete<cr>", desc = "Close buffer" }
 else
-  maps.n["<leader>c"] = { "<cmd>bdelete<cr>", desc = "Close buffer" }
+  maps.n["<leader>c"] = { "<cmd>bwipe<cr>", desc = "Close buffer" }
 end
 
 -- Navigate buffers


### PR DESCRIPTION
I'm not sure if `<leader>c` in this project was meant to use as shortcut to close a buffer or a "tab window", or maybe has something to do with Session Manager.
But since `<leader>q` already does the job of quitting Nvim. If `<leader>c` was meant for closing a single buffer, then the correct vim command should probably be `:bwipe` instead of `:bdelete`