### PR TITLE
Fixes client.resolved_capabilities.document_formatting

### DIFF
--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -31,7 +31,7 @@ astronvim.lsp.on_attach = function(client, bufnr)
     { desc = "Format file with LSP" }
   )
 
-  if client.resolved_capabilities.document_highlight then
+  if client.server_capabilities.DocumentHighlight then
     vim.api.nvim_create_augroup("lsp_document_highlight", { clear = true })
     vim.api.nvim_create_autocmd("CursorHold", {
       group = "lsp_document_highlight",
@@ -85,6 +85,6 @@ function astronvim.lsp.server_settings(server_name)
   return opts
 end
 
-function astronvim.lsp.disable_formatting(client) client.resolved_capabilities.document_formatting = false end
+function astronvim.lsp.disable_formatting(client) client.server_capabilities.documentFormattingProvider = false end
 
 return astronvim.lsp


### PR DESCRIPTION
I kept on seeing this error message when opening .js files:

```resolved_capabilities is deprecated, update your plugins or configuration to access client.server_capabilities instead. The new key/value pairs in server_capabilities directly match those defined in the language server protocol```

via https://github.com/neovim/nvim-lspconfig/issues/1891 - editing handles.lua with these new values made the error go away. I also have no idea what I'm doing, but the error message is gone, so there's that :)