### PR TITLE
chore(stylua): `no_call_parentheses` -> `call_parentheses`

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -3,5 +3,5 @@ line_endings = "Unix"
 indent_type = "Spaces"
 indent_width = 2
 quote_style = "AutoPreferDouble"
-no_call_parentheses = true
+call_parentheses = "None"
 collapse_simple_statement = "Always"


### PR DESCRIPTION
The option has changed since https://github.com/JohnnyMorganz/StyLua/releases/tag/v0.12.0.

> ### Deprecated
> - Option `no_call_parentheses` has been deprecated. Use `call_parentheses = "None"` instead.