### PR TITLE
fix(telescope,alpha): search icon on iTerm2

### DIFF
--- a/lua/configs/alpha.lua
+++ b/lua/configs/alpha.lua
@@ -25,7 +25,7 @@ alpha.setup(astronvim.user_plugin_opts("plugins.alpha", {
     {
       type = "group",
       val = {
-        alpha_button("LDR f f", "  Find File  "),
+        alpha_button("LDR f f", "  Find File  "),
         alpha_button("LDR f o", "  Recents  "),
         alpha_button("LDR f w", "  Find Word  "),
         alpha_button("LDR f n", "  New File  "),

--- a/lua/configs/telescope.lua
+++ b/lua/configs/telescope.lua
@@ -8,7 +8,7 @@ astronvim.conditional_func(telescope.load_extension, pcall(require, "aerial"), "
 telescope.setup(astronvim.user_plugin_opts("plugins.telescope", {
   defaults = {
 
-    prompt_prefix = " ",
+    prompt_prefix = " ",
     selection_caret = "❯ ",
     path_display = { "truncate" },
     selection_strategy = "reset",


### PR DESCRIPTION
As mentioned in issue [AstroNvim/issues/812](https://github.com/AstroNvim/AstroNvim/issues/812), the search icon in telescope is not working on iTerm2 terminal on mac with nerd font. To solve this problem, there is an other search icon that is really similar that works on Mac iTerm2 terminals.

This change is to fix this to allow all platform to have the search icon on telescope and the dashboard.

The exact change is the replacement of the `nf-oct-search` icon for the `nf-fa-search` icon.

<img width="481" alt="image" src="https://user-images.githubusercontent.com/43208288/182750511-ef661f7e-0c72-483c-8d4e-9eb891fd3ae7.png">

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/43208288/182750575-fc77aada-b5ca-46f3-a7dc-22ea4825a142.png">

These two screenshot were made on iTerm2 terminals with nvim version : 
```
NVIM v0.7.0
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by brew@Monterey
```
Font is MesloLGS NF

