### PR TITLE
chore(nvim-colorizer): switch to maintained fork

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -196,7 +196,7 @@ local astro_plugins = {
   },
 
   -- Color highlighting
-  ["norcalli/nvim-colorizer.lua"] = {
+  ["NvChad/nvim-colorizer.lua"] = {
     event = { "BufRead", "BufNewFile" },
     config = function() require "configs.colorizer" end,
   },


### PR DESCRIPTION
This is NvChad's fork of nvim-colorizer, which they use in their own project. It seems to be the most active out of the other forks. See https://github.com/norcalli/nvim-colorizer.lua/issues/75.