### PR TITLE
Neo-Tree Improvements

### DIFF
--- a/lua/configs/window-picker.lua
+++ b/lua/configs/window-picker.lua
@@ -1,0 +1,4 @@
+local status_ok, window_picker = pcall(require, "window-picker")
+if not status_ok then return end
+local colors = require "default_theme.colors"
+window_picker.setup(astronvim.user_plugin_opts("plugins.window-picker", { other_win_hl_color = colors.grey_4 }))

--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -12,6 +12,26 @@ cmd({ "VimEnter", "FileType", "BufEnter", "WinEnter" }, {
   callback = function() astronvim.set_url_match() end,
 })
 
+augroup("auto_quit", { clear = true })
+cmd("BufEnter", {
+  desc = "Quit AstroNvim if more than one window is open and only sidebar windows are list",
+  group = "auto_quit",
+  callback = function()
+    local num_wins = #vim.api.nvim_list_wins()
+    local not_sidebars = num_wins
+    local sidebar_fts = { "aerial", "neo-tree" }
+    for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+      if
+        vim.api.nvim_buf_is_loaded(bufnr)
+        and vim.tbl_contains(sidebar_fts, vim.api.nvim_buf_get_option(bufnr, "filetype"))
+      then
+        not_sidebars = not_sidebars - 1
+      end
+    end
+    if num_wins > 1 and not_sidebars == 0 then vim.cmd "quit" end
+  end,
+})
+
 if is_available "alpha-nvim" then
   augroup("alpha_settings", { clear = true })
   if is_available "bufferline.nvim" then

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -62,6 +62,12 @@ local astro_plugins = {
   -- Better buffer closing
   ["famiu/bufdelete.nvim"] = { cmd = { "Bdelete", "Bwipeout" } },
 
+  ["s1n7ax/nvim-window-picker"] = {
+    tag = "v1.*",
+    module = "window-picker",
+    config = function() require "configs.window-picker" end,
+  },
+
   -- File explorer
   ["nvim-neo-tree/neo-tree.nvim"] = {
     branch = "v2.x",


### PR DESCRIPTION
Neo-tree has added window picker keybindings which require a window-picker to be installed. This adds one and fully lazy loads it on it's module. If the user  never uses the keybinding then the plugin never loads.

This also adds an auto command that will auto close AstroNvim if a window is closed and only Aerial and Neo-tree are opened.

Resolves #733