### PR TITLE
Add missing range code action mapping

### DIFF
--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -34,6 +34,9 @@ astronvim.lsp.on_attach = function(client, bufnr)
         ["]d"] = { function() vim.diagnostic.goto_next() end, desc = "Next diagnostic" },
         ["gl"] = { function() vim.diagnostic.open_float() end, desc = "Hover diagnostics" },
       },
+      v = {
+        ["<leader>la"] = { function() vim.lsp.buf.range_code_action() end, desc = "Range LSP code action" },
+      },
     }),
     { buffer = bufnr }
   )


### PR DESCRIPTION
Hey when I was switching from VSCode to Astro I noticed that I couldn't refactor code when being in visual mode. I used that feautre very often in VSC when was working with Rust code