### PR TITLE
Fix formatting.filter

### DIFF
--- a/lua/core/utils/lsp.lua
+++ b/lua/core/utils/lsp.lua
@@ -34,8 +34,11 @@ end
 -- @return true if the client should be used for formatting
 astronvim.lsp.format_filter = function(client)
   local formatting = astronvim.user_plugin_opts("lsp.formatting", { disabled = {} })
-  return type(formatting.filter) == "function" and formatting.filter(client)
-    or not vim.tbl_contains(formatting.disabled, client.name)
+  if type(formatting.filter) == "function" then
+    return formatting.filter(client)
+  else
+    return not vim.tbl_contains(formatting.disabled, client.name)
+  end
 end
 
 --- The `on_attach` function used by AstroNvim


### PR DESCRIPTION
Fix not being able to globally disable format on save.

I had set a filter to always return false. So I ended up with this:

`type(formatting.filter) == "function"` == `true`.

`formatting.filter(client)` == `false`.

`true and false` == `false`.

So the branch after the `or` got evaluated, overriding my global "don't do that!".