### PR TITLE
feat(status): remove duplicate LSP client names

### DIFF
--- a/lua/core/status.lua
+++ b/lua/core/status.lua
@@ -83,6 +83,17 @@ function M.provider.lsp_client_names(expand_null_ls)
         table.insert(buf_client_names, client.name)
       end
     end
+
+    -- remove duplicates LSP names from array
+    local seen = {}
+    for index,item in ipairs(buf_client_names) do
+      if seen[item] then
+        table.remove(buf_client_names, index)
+      else
+        seen[item] = true
+      end
+    end
+
     return table.concat(buf_client_names, ", ")
   end
 end


### PR DESCRIPTION
## what
- remove duplicate LSP client names

## how
- Use a hashset to determine a LSP client name already exists in the table
  - if it exists, remove from the table
- obtained from https://programming-idioms.org/idiom/119/deduplicate-list/4283/lua

## why
- No need to have duplicate LSP client names to be displayed (ex: displayed in feline)

## where
- ./lua/core/status.lua

## usage