### PR TITLE
feat(plugins): add mason-null-ls plugin

### DIFF
--- a/lua/configs/mason-null-ls.lua
+++ b/lua/configs/mason-null-ls.lua
@@ -1,0 +1,9 @@
+local status_ok, mason_null_ls = pcall(require, "mason-null-ls")
+if not status_ok then return end
+mason_null_ls.setup(astronvim.user_plugin_opts "plugins.mason-null-ls")
+mason_null_ls.setup_handlers(
+  astronvim.user_plugin_opts(
+    "mason-null-ls.setup_handlers",
+    { function(server) astronvim.null_ls_register(server) end }
+  )
+)

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -162,6 +162,12 @@ local astro_plugins = {
   ["neovim/nvim-lspconfig"] = {},
 
   -- LSP manager
+  ["jayp0521/mason-null-ls.nvim"] = {
+    after = { "mason.nvim", "null-ls.nvim" },
+    config = function() require "configs.mason-null-ls" end,
+  },
+
+  -- LSP manager
   ["williamboman/mason-lspconfig.nvim"] = {
     after = { "mason.nvim", "nvim-lspconfig" },
     config = function() require "configs.lsp" end,

--- a/lua/core/utils/init.lua
+++ b/lua/core/utils/init.lua
@@ -331,6 +331,20 @@ function astronvim.null_ls_providers(filetype)
   return registered
 end
 
+--- Register a null-ls source given a name if it has not been manually configured in the null-ls configuration
+-- @param source the source name to register from all builtin types
+function astronvim.null_ls_register(source)
+  -- try to load null-ls
+  local null_ls_avail, null_ls = pcall(require, "null-ls")
+  if null_ls_avail then
+    if null_ls.is_registered(source) then return end
+    for _, type in ipairs { "diagnostics", "formatting", "code_actions", "completion", "hover" } do
+      local builtin = require("null-ls.builtins._meta." .. type)
+      if builtin[source] then null_ls.register(null_ls.builtins[type][source]) end
+    end
+  end
+end
+
 --- Get the null-ls sources for a given null-ls method
 -- @param filetype the filetype to search null-ls for
 -- @param method the null-ls method (check null-ls documentation for available methods)


### PR DESCRIPTION
This allows users to install null-ls sources automatically along with setting up sources similar to how `lspconfig` is configured with `mason-lspconfig`