### PR TITLE
fix(laststatus): respect user configurations

### DIFF
--- a/lua/core/autocmds.lua
+++ b/lua/core/autocmds.lua
@@ -58,7 +58,8 @@ if is_available "alpha-nvim" then
     group = "alpha_settings",
     pattern = "alpha",
     callback = function()
-      local prev_status = vim.opt.laststatus
+      local user_opts = require "user.options"
+      local prev_status = user_opts.g.laststatus or user_opts.opt.laststatus or vim.opt.laststatus
       vim.opt.laststatus = 0
       cmd("BufUnload", {
         pattern = "<buffer>",


### PR DESCRIPTION
Setting `vim.opt.laststatus` in init.vim through the `g` or `opt` keys isn't respected when we leave the Alpha page 