### PR TITLE
swapping deprecated calls in lsp/handlers.lua

### DIFF
--- a/lua/configs/lsp/handlers.lua
+++ b/lua/configs/lsp/handlers.lua
@@ -58,7 +58,7 @@ astronvim.lsp.on_attach = function(client, bufnr)
     { desc = "Format file with LSP" }
   )
 
-  if client.resolved_capabilities.document_highlight then
+  if client.server_capabilities.document_highlight then
     vim.api.nvim_create_augroup("lsp_document_highlight", { clear = true })
     vim.api.nvim_create_autocmd("CursorHold", {
       group = "lsp_document_highlight",
@@ -113,8 +113,8 @@ function astronvim.lsp.server_settings(server_name)
 end
 
 function astronvim.lsp.disable_formatting(client)
-  client.resolved_capabilities.document_formatting = false
-  client.resolved_capabilities.document_range_formatting = false
+  client.server_capabilities.document_formatting = false
+  client.server_capabilities.document_range_formatting = false
 end
 
 return astronvim.lsp


### PR DESCRIPTION
I was receiving an error msg on startup so I swapped the deprecated calls in lsp/handlers.lua

switched from client.resolved_capabilities  -> client.server_capabilities. 