### PR TITLE
feat(lsp): support format_on_save whitelist

### DIFF
--- a/lua/core/utils/lsp.lua
+++ b/lua/core/utils/lsp.lua
@@ -87,12 +87,17 @@ astronvim.lsp.on_attach = function(client, bufnr)
       { desc = "Format file with LSP" }
     )
     local format_on_save = astronvim.lsp.formatting.format_on_save
+    local filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
     if
       format_on_save == true
       or (
         type(format_on_save) == "table"
         and format_on_save.enabled == true
-        and not vim.tbl_contains(format_on_save.ignore_filetypes or {}, vim.api.nvim_buf_get_option(bufnr, "filetype"))
+        and (
+          next(format_on_save.allow_filetypes or {}) ~= nil
+            and vim.tbl_contains(format_on_save.allow_filetypes, filetype)
+          or not vim.tbl_contains(format_on_save.ignore_filetypes or {}, filetype)
+        )
       )
     then
       local autocmd_group = "auto_format_" .. bufnr

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -143,7 +143,10 @@ local config = {
       -- control auto formatting on save
       format_on_save = {
         enabled = true, -- enable or disable format on save globally
-        disable_filetypes = { -- disable format on save for specified filetypes
+        allow_filetypes = { -- enable format on save for specified filetypes only
+          -- "go",
+        },
+        ignore_filetypes = { -- disable format on save for specified filetypes
           -- "python",
         },
       },


### PR DESCRIPTION
This adds a whitelist approach to `format_on_save` in addition to the existing blacklist.

Personally, I know which languages are "ok" to format on save, I do not know all the languages that are not