### PR TITLE
fix(lsp): fix format_on_save whitelist

### DIFF
--- a/lua/core/utils/lsp.lua
+++ b/lua/core/utils/lsp.lua
@@ -94,7 +94,8 @@ astronvim.lsp.on_attach = function(client, bufnr)
         type(format_on_save) == "table"
         and format_on_save.enabled == true
         and (
-          next(format_on_save.allow_filetypes or {}) and vim.tbl_contains(format_on_save.allow_filetypes, filetype)
+          next(format_on_save.allow_filetypes or {}) ~= nil
+            and vim.tbl_contains(format_on_save.allow_filetypes, filetype)
           or not vim.tbl_contains(format_on_save.ignore_filetypes or {}, filetype)
         )
       )


### PR DESCRIPTION
I do not know what happened, but the commit that ended up in Nightly (720db1f2487ea7f1c1081aa50ecb2dcb61cba4c7) is not the commit that was approved in #1133.