### PR TITLE
chore:  fix typo in mappings.lua  desc

### DIFF
--- a/lua/core/mappings.lua
+++ b/lua/core/mappings.lua
@@ -199,7 +199,7 @@ maps.v[">"] = { ">gv", desc = "indent line" }
 maps.t["<C-h>"] = { "<c-\\><c-n><c-w>h", desc = "Terminal left window navigation" }
 maps.t["<C-j>"] = { "<c-\\><c-n><c-w>j", desc = "Terminal down window navigation" }
 maps.t["<C-k>"] = { "<c-\\><c-n><c-w>k", desc = "Terminal up window navigation" }
-maps.t["<C-l>"] = { "<c-\\><c-n><c-w>l", desc = "Terminal right window naviation" }
+maps.t["<C-l>"] = { "<c-\\><c-n><c-w>l", desc = "Terminal right window navigation" }
 
 -- Custom menu for modification of the user experience
 if is_available "nvim-autopairs" then


### PR DESCRIPTION
Lack of g in the word description

naviation→navigation