### PR TITLE
chore(user_example): remove extra space in comment

### DIFF
--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -38,7 +38,7 @@ local config = {
     -- },
   },
 
-  -- set vim options here (vim.<first_key>.<second_key> =  value)
+  -- set vim options here (vim.<first_key>.<second_key> = value)
   options = {
     opt = {
       -- set to true or false etc.


### PR DESCRIPTION
Sorry @minhd-vu! I accidentally reverted this. 