### PR TITLE
chore(default_theme): Add missing Aerial icon

### DIFF
--- a/lua/default_theme/plugins/aerial.lua
+++ b/lua/default_theme/plugins/aerial.lua
@@ -25,6 +25,7 @@ return {
   AerialPropertyIcon = { link = "@property" },
   AerialStringIcon = { link = "@string" },
   AerialStructIcon = { link = "@type" },
+  AerialTypeIcon = { link = "@type" },
   AerialTypeParameterIcon = { link = "@parameter" },
   AerialVariableIcon = { link = "@variable" },
 }


### PR DESCRIPTION
This stops areial from erroring out three times on each cursor move, asking for AerialTypeIcon :-)