### PR TITLE
fix: unnecessary configuration option

### DIFF
--- a/lua/configs/lspkind.lua
+++ b/lua/configs/lspkind.lua
@@ -1,7 +1,6 @@
 local status_ok, lspkind = pcall(require, "lspkind")
 if not status_ok then return end
 astronvim.lspkind = astronvim.user_plugin_opts("plugins.lspkind", {
-  mode = "symbol",
   symbol_map = {
     NONE = "",
     Array = "",


### PR DESCRIPTION
`symbol` is already the default
