### PR TITLE
fix(plugins): setting up mason before loading add-ons

### DIFF
--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -180,8 +180,8 @@ local astro_plugins = {
       "MasonUpdateAll", -- astronvim command
     },
     config = function()
-      vim.tbl_map(function(plugin) pcall(require, plugin) end, { "lspconfig", "null-ls" })
       require "configs.mason"
+      vim.tbl_map(function(plugin) pcall(require, plugin) end, { "lspconfig", "null-ls" })
     end,
   },
 


### PR DESCRIPTION
Existing configuration, where `mason.nvim` `config` function requires `lspconfig` and `null-ls` before requiring `configs.mason`, creates a race condition due to plugin load order. `mason.nvim` add-on plugins - `mason-lspconfig.nvim` and `mason-null-ls.nvim` - start executing their installation hooks before `mason.nvim` configuration is loaded. During installation the `mason.nvim` configuration is loaded, therefore changing the settings and leading to errors like this (taken from `mason.log`):

```shell
[INFO  Tue Nov 29 11:59:24 2022] ...acker\start\mason.nvim/lua\mason-core\installer\init.lua:118: Executing installer for Package(name=lua-language-server)
[ERROR Tue Nov 29 11:59:25 2022] ...acker\start\mason.nvim/lua\mason-core\installer\init.lua:154: Installation failed for Package(name=lua-language-server) error='...acker\\start\\mason.nvim/lua\\mason-core\\installer\\init.lua:121: ...er\\start\\mason.nvim/lua\\mason-core\\installer\\context.lua:128: "C:\\\\Users\\\\yehorb\\\\Tools\\\\mason\\\\.packages\\\\lua-language-server" is not a subdirectory of "C:\\\\Users\\\\yehorb\\\\AppData\\\\Local\\\\nvim-data\\\\mason"'
```

As you can see, I have a `C:\Users\yehorb\Tools\mason` directory set as the `install_root_dir` in `user.plugins.mason`, but `mason-null-ls.nvim` uses the default value of `C:\Users\yehorb\AppData\Local\nvim-data\mason` to start the installation. Then, during the installation, settings change (because `settings` is the global table) and the error appears.

I was not really able to debug the plugin load order and how this happens exactly, it looks like `packer.nvim` is not really able to infer the correct load order. Or, more likely, `require` inside of the `config` block messes up the load order.

Without the fix I consistently get the error above; with it, I do not. Although it feels more like a fix for the symptom rather than for the issue.

Following all of the above, I also have a question: is lazy-loading such "system-ish" plugins like `mason.nvim` and `treesitter.nvim` really necessary? They have quite a few add-on plugins, that depend on the "core" plugin being properly loaded and configured. Which, as I can see, is not always the case. And `mason.nvim` explicitly states that [lazy-loading is not recommended](https://github.com/williamboman/mason.nvim#setup).

I really do appreciate the call to optimize the `AstroNvim` as much as possible, but I also think that lazy-loading everything is also a way to introduce elusive bugs, as plugin load order becomes unclear. I did not really know how many milliseconds lazy-loading `mason.nvim` saves, but I already spend a good few hours trying to understand the given issue.