### PR TITLE
fix: heirline new setup method

### DIFF
--- a/lua/configs/heirline.lua
+++ b/lua/configs/heirline.lua
@@ -282,7 +282,7 @@ local heirline_opts = astronvim.user_plugin_opts("plugins.heirline", {
       }
     or nil,
 })
-heirline.setup(heirline_opts[1], heirline_opts[2], heirline_opts[3])
+heirline.setup({statusline=heirline_opts[1], winbar=heirline_opts[2], tabline=heirline_opts[3]})
 
 local augroup = vim.api.nvim_create_augroup("Heirline", { clear = true })
 vim.api.nvim_create_autocmd("User", {


### PR DESCRIPTION
- Heirline has introduced a breaking change in the setup method with commit https://github.com/rebelot/heirline.nvim/commit/7b57b27e9e4d1ffa4f3e149f8fdc927db18a850a that prevent AstroNvim from starting without errors.

This MR calls the new setup method with the correct parameters.