### PR TITLE
fix(dap): not loading dap on all files

### DIFF
--- a/lua/plugins/configs/mason.lua
+++ b/lua/plugins/configs/mason.lua
@@ -1,6 +1,6 @@
 return function(_, opts)
   require("mason").setup(opts)
-  for _, plugin in ipairs { "mason-lspconfig", "mason-null-ls", "mason-nvim-dap" } do
+  for _, plugin in ipairs { "mason-lspconfig", "mason-null-ls" } do
     pcall(require, plugin)
   end
 end

--- a/lua/plugins/dap.lua
+++ b/lua/plugins/dap.lua
@@ -4,7 +4,6 @@ return {
   dependencies = {
     {
       "jay-babu/mason-nvim-dap.nvim",
-      dependencies = { "nvim-dap" },
       cmd = { "DapInstall", "DapUninstall" },
       opts = { automatic_setup = true },
       config = require "plugins.configs.mason-nvim-dap",
@@ -15,5 +14,4 @@ return {
       config = require "plugins.configs.nvim-dap-ui",
     },
   },
-  init = function() table.insert(astronvim.file_plugins, "nvim-dap") end,
 }


### PR DESCRIPTION
when i open a md or a txt dap is loaded. 
this adds more then 40ms to the loadtime when a file is directly opens.
i guess dap needs some manual configuration anyways, so maybe it makes sense to let the user load it. 