### PR TITLE
feat: toggle diagnostics visibility between more options

### DIFF
--- a/lua/core/diagnostics.lua
+++ b/lua/core/diagnostics.lua
@@ -17,13 +17,51 @@ for _, sign in ipairs(signs) do
 end
 
 astronvim.lsp.diagnostics = {
-  off = {
+  -- diagnostics off
+  [0] = {
+    -- status = "all diagnostics off",
     underline = false,
     virtual_text = false,
     signs = false,
     update_in_insert = false,
   },
-  on = astronvim.user_plugin_opts("diagnostics", {
+  -- status only
+  [1] = {
+    -- status = "status diagnostics only",
+    virtual_text = false,
+    signs = false,
+    update_in_insert = true,
+    underline = true,
+    severity_sort = true,
+    float = {
+      focused = false,
+      style = "minimal",
+      border = "rounded",
+      source = "always",
+      header = "",
+      prefix = "",
+    },
+  },
+  -- virtual text off, signs on
+  [2] = {
+    -- status = "virtual text off",
+    virtual_text = false,
+    signs = { active = signs },
+    update_in_insert = true,
+    underline = true,
+    severity_sort = true,
+    float = {
+      focused = false,
+      style = "minimal",
+      border = "rounded",
+      source = "always",
+      header = "",
+      prefix = "",
+    },
+  },
+  -- all diagnostics on
+  [3] = {
+    -- status = "all diagnostics on",
     virtual_text = true,
     signs = { active = signs },
     update_in_insert = true,
@@ -37,7 +75,7 @@ astronvim.lsp.diagnostics = {
       header = "",
       prefix = "",
     },
-  }),
+  },
 }
 
-vim.diagnostic.config(astronvim.lsp.diagnostics[vim.g.diagnostics_enabled and "on" or "off"])
+vim.diagnostic.config(astronvim.lsp.diagnostics[vim.g.diagnostics_mode])

--- a/lua/core/diagnostics.lua
+++ b/lua/core/diagnostics.lua
@@ -19,7 +19,6 @@ end
 astronvim.lsp.diagnostics = {
   -- diagnostics off
   [0] = {
-    -- status = "all diagnostics off",
     underline = false,
     virtual_text = false,
     signs = false,
@@ -27,7 +26,6 @@ astronvim.lsp.diagnostics = {
   },
   -- status only
   [1] = {
-    -- status = "status diagnostics only",
     virtual_text = false,
     signs = false,
     update_in_insert = true,
@@ -44,7 +42,6 @@ astronvim.lsp.diagnostics = {
   },
   -- virtual text off, signs on
   [2] = {
-    -- status = "virtual text off",
     virtual_text = false,
     signs = { active = signs },
     update_in_insert = true,
@@ -61,7 +58,6 @@ astronvim.lsp.diagnostics = {
   },
   -- all diagnostics on
   [3] = {
-    -- status = "all diagnostics on",
     virtual_text = true,
     signs = { active = signs },
     update_in_insert = true,

--- a/lua/core/diagnostics.lua
+++ b/lua/core/diagnostics.lua
@@ -25,7 +25,7 @@ astronvim.lsp.diagnostics = {
     update_in_insert = false,
   },
   -- status only
-  [1] = {
+  [1] = astronvim.user_plugin_opts("diagnostics", {
     virtual_text = false,
     signs = false,
     update_in_insert = true,
@@ -39,9 +39,9 @@ astronvim.lsp.diagnostics = {
       header = "",
       prefix = "",
     },
-  },
+  }),
   -- virtual text off, signs on
-  [2] = {
+  [2] = astronvim.user_plugin_opts("diagnostics", {
     virtual_text = false,
     signs = { active = signs },
     update_in_insert = true,
@@ -55,9 +55,9 @@ astronvim.lsp.diagnostics = {
       header = "",
       prefix = "",
     },
-  },
+  }),
   -- all diagnostics on
-  [3] = {
+  [3] = astronvim.user_plugin_opts("diagnostics", {
     virtual_text = true,
     signs = { active = signs },
     update_in_insert = true,
@@ -71,7 +71,7 @@ astronvim.lsp.diagnostics = {
       header = "",
       prefix = "",
     },
-  },
+  }),
 }
 
 vim.diagnostic.config(astronvim.lsp.diagnostics[vim.g.diagnostics_mode])

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -60,8 +60,7 @@ astronvim.vim_opts(astronvim.user_plugin_opts("options", {
     lsp_handlers_enabled = true, -- enable or disable default vim.lsp.handlers (hover and signatureHelp)
     cmp_enabled = true, -- enable completion at start
     autopairs_enabled = true, -- enable autopairs at start
-    diagnostics_enabled = true, -- enable diagnostics at start
-    status_diagnostics_enabled = true, -- enable diagnostics in statusline
+    diagnostics_mode = 3, -- set the visibility of diagnostics in the UI (0=off, 1=only show in status line, 2=virtual text off, 3=all on)
     icons_enabled = true, -- disable icons in the UI (disable if no nerd font is available)
     ui_notifications_enabled = true, -- disable notifications when toggling UI elements
     heirline_bufferline = false, -- enable heirline bufferline (TODO v3: remove this option and make it default)

--- a/lua/core/utils/status.lua
+++ b/lua/core/utils/status.lua
@@ -692,7 +692,7 @@ end
 -- @usage local heirline_component = { provider = "Example Provider", condition = astronvim.status.condition.has_diagnostics }
 function astronvim.status.condition.has_diagnostics(bufnr)
   if type(bufnr) == "table" then bufnr = bufnr.bufnr end
-  return vim.g.status_diagnostics_enabled and #vim.diagnostic.get(bufnr or 0) > 0
+  return vim.g.diagnostics_mode > 0 and #vim.diagnostic.get(bufnr or 0) > 0
 end
 
 --- A condition function if there is a defined filetype

--- a/lua/core/utils/ui.lua
+++ b/lua/core/utils/ui.lua
@@ -41,22 +41,17 @@ end
 
 --- Toggle diagnostics
 function astronvim.ui.toggle_diagnostics()
-  local status = "on"
-  if vim.g.status_diagnostics_enabled then
-    if vim.g.diagnostics_enabled then
-      vim.g.diagnostics_enabled = false
-      status = "virtual text off"
+  vim.g.diagnostics_mode = (vim.g.diagnostics_mode - 1) % 4
+  vim.diagnostic.config(astronvim.lsp.diagnostics[vim.g.diagnostics_mode])
+  if (vim.g.diagnostics_mode == 0) then
+    ui_notify("diagnostics off")
+  elseif (vim.g.diagnostics_mode == 1) then
+    ui_notify("only status diagnostics")
+  elseif (vim.g.diagnostics_mode == 2) then
+    ui_notify("virtual text off")
     else
-      vim.g.status_diagnostics_enabled = false
-      status = "fully off"
+    ui_notify("all diagnostics on")
     end
-  else
-    vim.g.diagnostics_enabled = true
-    vim.g.status_diagnostics_enabled = true
-  end
-
-  vim.diagnostic.config(astronvim.lsp.diagnostics[bool2str(vim.g.diagnostics_enabled)])
-  ui_notify(string.format("diagnostics %s", status))
 end
 
 --- Toggle background="dark"|"light"

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -130,7 +130,6 @@ local config = {
 
   -- Diagnostics configuration (for vim.diagnostics.config({...})) when diagnostics are on
   diagnostics = {
-    virtual_text = true,
     underline = true,
   },
 

--- a/lua/user_example/init.lua
+++ b/lua/user_example/init.lua
@@ -53,8 +53,7 @@ local config = {
       autoformat_enabled = true, -- enable or disable auto formatting at start (lsp.formatting.format_on_save must be enabled)
       cmp_enabled = true, -- enable completion at start
       autopairs_enabled = true, -- enable autopairs at start
-      diagnostics_enabled = true, -- enable diagnostics at start
-      status_diagnostics_enabled = true, -- enable diagnostics in statusline
+      diagnostics_mode = 3, -- set the visibility of diagnostics in the UI (0=off, 1=only show in status line, 2=virtual text off, 3=all on)
       icons_enabled = true, -- disable icons in the UI (disable if no nerd font is available, requires :PackerSync after changing)
       ui_notifications_enabled = true, -- disable notifications when toggling UI elements
       heirline_bufferline = false, -- enable new heirline based bufferline (requires :PackerSync after changing)


### PR DESCRIPTION
There is currently an option to toggle between diagnostics, but toggling "virtual text off" also removes the diagnostics from the sign column. In a lot of situations, it makes sense to turn off virtual text but continue to show line diagnostics on the side, like when the window gets too cluttered. The config files have to be updated on the user's end; instead of setting both `diagnostics_enabled` and `status_diagnostics_enabled`, the user sets a single option `diagnostics_mode`, which determines the initial visibility for diagnostics. 

This is my first ever PR and my first experience with Lua, so I would greatly appreciate any feedback or areas of improvement for future contributions. Thanks!

![Screen Recording 2023-02-24 at 2 57 22 PM](https://user-images.githubusercontent.com/56745535/221318781-2297cca9-3977-4ec1-b15f-16cce2bacb98.gif)