### PR TITLE
feat: allow copying file name and absolute path in neo-tree

### DIFF
--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -83,7 +83,7 @@ return {
           O = "system_open",
           h = "parent_or_close",
           l = "child_or_open",
-          ["Y"] = "copy_file_name",
+          Y = "copy_file_name",
           ["<C-y>"] = "copy_absolute_path",
         },
       },

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -27,10 +27,7 @@ return {
           state.commands.open(state)
         end
       end,
-      copy_file_name = function(state)
-        local node = state.tree:get_node();
-        vim.fn.setreg('*', node.name, 'c')
-      end,
+      copy_name = function(state) vim.fn.setreg("+", state.tree:get_node().name) end,
       copy_absolute_path = function(state)
         local node = state.tree:get_node();
         local full_path = node.path;

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -28,11 +28,7 @@ return {
         end
       end,
       copy_name = function(state) vim.fn.setreg("+", state.tree:get_node().name) end,
-      copy_absolute_path = function(state)
-        local node = state.tree:get_node();
-        local full_path = node.path;
-        vim.fn.setreg('*', full_path, 'c')
-      end,
+      copy_path = function(state) vim.fn.setreg("+", state.tree:get_node().path) end,
     }
     local get_icon = require("astronvim.utils").get_icon
     return {
@@ -80,8 +76,8 @@ return {
           O = "system_open",
           h = "parent_or_close",
           l = "child_or_open",
-          Y = "copy_file_name",
-          ["<C-y>"] = "copy_absolute_path",
+          Y = "copy_name",
+          ["<C-y>"] = "copy_path",
         },
       },
       filesystem = {

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -27,6 +27,15 @@ return {
           state.commands.open(state)
         end
       end,
+      copy_file_name = function(state)
+        local node = state.tree:get_node();
+        vim.fn.setreg('*', node.name, 'c')
+      end,
+      copy_absolute_path = function(state)
+        local node = state.tree:get_node();
+        local full_path = node.path;
+        vim.fn.setreg('*', full_path, 'c')
+      end,
     }
     local get_icon = require("astronvim.utils").get_icon
     return {
@@ -74,6 +83,8 @@ return {
           O = "system_open",
           h = "parent_or_close",
           l = "child_or_open",
+          ["Y"] = "copy_file_name",
+          ["<C-y>"] = "copy_absolute_path",
         },
       },
       filesystem = {


### PR DESCRIPTION
This will make it easier to copy file names and directories over to other applications, such as when you want to quickly locate a file in a system file explorer or cd into a directory in the terminal.