### PR TITLE
feat(neotree): add mapping to trash files

### DIFF
--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -83,7 +83,7 @@ return {
           O = "system_open",
           h = "parent_or_close",
           l = "child_or_open",
-          ["Y"] = "copy_file_name",
+          Y = "copy_file_name",
           ["<C-y>"] = "copy_absolute_path",
         },
       },

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -27,10 +27,7 @@ return {
           state.commands.open(state)
         end
       end,
-      copy_file_name = function(state)
-        local node = state.tree:get_node();
-        vim.fn.setreg('*', node.name, 'c')
-      end,
+      copy_name = function(state) vim.fn.setreg("+", state.tree:get_node().name) end,
       copy_absolute_path = function(state)
         local node = state.tree:get_node();
         local full_path = node.path;

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -34,10 +34,10 @@ return {
         local modify = vim.fn.fnamemodify
 
         local results = {
-          { val = filepath, msg = "Absolute path" },
+          { val = filepath,               msg = "Absolute path" },
           { val = modify(filepath, ":."), msg = "Path relative to CWD" },
           { val = modify(filepath, ":~"), msg = "Path relative to Home" },
-          { val = filename, msg = "Filename" },
+          { val = filename,               msg = "Filename" },
           { val = modify(filename, ":r"), msg = "Filename w/o extension" },
           { val = modify(filename, ":e"), msg = "Extension only" },
         }
@@ -60,6 +60,38 @@ return {
           vim.notify("Copied: " .. result.val)
           vim.fn.setreg("+", result.val)
         end
+      end,
+      trash = function(state)
+        local inputs = require("neo-tree.ui.inputs")
+        local path = state.tree:get_node().path
+        local msg = "Are you sure you want to trash " .. path
+        inputs.confirm(msg, function(confirmed)
+          if not confirmed then return end
+
+          vim.fn.system { "trash", vim.fn.fnameescape(path) }
+          require("neo-tree.sources.manager").refresh(state.name)
+        end)
+      end,
+      trash_visual = function(state, selected_nodes)
+        local inputs = require("neo-tree.ui.inputs")
+
+        function GetTableLen(tbl)
+          local len = 0
+          for _ in pairs(tbl) do
+            len = len + 1
+          end
+          return len
+        end
+
+        local count = GetTableLen(selected_nodes)
+        local msg = "Are you sure you want to trash " .. count .. " files ?"
+        inputs.confirm(msg, function(confirmed)
+          if not confirmed then return end
+          for _, node in ipairs(selected_nodes) do
+            vim.fn.system { "trash", vim.fn.fnameescape(node.path) }
+          end
+          require("neo-tree.sources.manager").refresh(state.name)
+        end)
       end,
     }
     local get_icon = require("astronvim.utils").get_icon
@@ -109,6 +141,7 @@ return {
           h = "parent_or_close",
           l = "child_or_open",
           Y = "copy_selector",
+          T = "trash",
         },
       },
       filesystem = {

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -28,11 +28,7 @@ return {
         end
       end,
       copy_name = function(state) vim.fn.setreg("+", state.tree:get_node().name) end,
-      copy_absolute_path = function(state)
-        local node = state.tree:get_node();
-        local full_path = node.path;
-        vim.fn.setreg('*', full_path, 'c')
-      end,
+      copy_path = function(state) vim.fn.setreg("+", state.tree:get_node().path) end,
     }
     local get_icon = require("astronvim.utils").get_icon
     return {
@@ -80,8 +76,8 @@ return {
           O = "system_open",
           h = "parent_or_close",
           l = "child_or_open",
-          Y = "copy_file_name",
-          ["<C-y>"] = "copy_absolute_path",
+          Y = "copy_name",
+          ["<C-y>"] = "copy_path",
         },
       },
       filesystem = {

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -27,6 +27,15 @@ return {
           state.commands.open(state)
         end
       end,
+      copy_file_name = function(state)
+        local node = state.tree:get_node();
+        vim.fn.setreg('*', node.name, 'c')
+      end,
+      copy_absolute_path = function(state)
+        local node = state.tree:get_node();
+        local full_path = node.path;
+        vim.fn.setreg('*', full_path, 'c')
+      end,
     }
     local get_icon = require("astronvim.utils").get_icon
     return {
@@ -74,6 +83,8 @@ return {
           O = "system_open",
           h = "parent_or_close",
           l = "child_or_open",
+          ["Y"] = "copy_file_name",
+          ["<C-y>"] = "copy_absolute_path",
         },
       },
       filesystem = {


### PR DESCRIPTION
This will allow the option of sending files/folders to the system's trash instead of permanently deleting them [(Source)](https://github.com/nvim-neo-tree/neo-tree.nvim/issues/202). However, this only works of the OS supports it — on MacOS, you need to run `brew install trash` to install the CLI command.

![Screen Recording 2023-02-26 at 11 49 21 PM](https://user-images.githubusercontent.com/56745535/221505831-2f17bfa0-ebac-4fea-bf3f-b7506688c485.gif)
