### PR TITLE
Update heirline setup from 3 arguments to single config argument

### DIFF
--- a/lua/configs/heirline.lua
+++ b/lua/configs/heirline.lua
@@ -282,7 +282,11 @@ local heirline_opts = astronvim.user_plugin_opts("plugins.heirline", {
       }
     or nil,
 })
-heirline.setup(heirline_opts[1], heirline_opts[2], heirline_opts[3])
+heirline.setup({
+  statusline = heirline_opts[1],
+  winbar = heirline_opts[2],
+  tabline = heirline_opts[3],
+})
 
 local augroup = vim.api.nvim_create_augroup("Heirline", { clear = true })
 vim.api.nvim_create_autocmd("User", {


### PR DESCRIPTION
Got an error after updating AstroVim and packages regarding heriline, telling me only a single config argument should be used in setup.

According to the cookbook (https://github.com/rebelot/heirline.nvim/blob/master/cookbook.md) it says:

```
-- the winbar parameter is optional!
require("heirline").setup({
    statusline = StatusLine,
    winbar = WinBar,
    tabline = TabLine,
    statuscolumn = StatusColumn
})
```
still somewhat odd and maybe in development since StatusColumn is not even explained how to be built (and says winbar is optional), however at least after this patch astrovim does not error out.

The Heirline change was marked as breaking in https://github.com/rebelot/heirline.nvim/commit/7b57b27e9e4d1ffa4f3e149f8fdc927db18a850a 