### PR TITLE
fix(lsp): update b0o/SchemaStore.nvim to support yaml

### DIFF
--- a/lua/lazy_snapshot.lua
+++ b/lua/lazy_snapshot.lua
@@ -7,7 +7,7 @@ return {
   { "NvChad/nvim-colorizer.lua", commit = "dde3084106a70b9a79d48f426f6d6fec6fd203f7" },
   { "Shatur/neovim-session-manager", commit = "e7a2cbf56b5fd3a223f2774b535499fc62eca6ef" },
   { "akinsho/toggleterm.nvim", commit = "98e15df2c838fe5c3cae1efa36fa5c255fc75aa8" },
-  { "b0o/SchemaStore.nvim", commit = "083485d0ec106c46eb38b525342dc8e23a9921c9" },
+  { "b0o/SchemaStore.nvim", commit = "1dc606bf07e1419d785e04d6dbb8585987d817cc" },
   { "famiu/bufdelete.nvim", commit = "8933abc09df6c381d47dc271b1ee5d266541448e" },
   { "folke/lazy.nvim", version = "^9" },
   { "folke/neodev.nvim", version = "^2" },


### PR DESCRIPTION
Follow up on c1b2f134eb25fb1593d49d6ad5a35202148bac5a, the Lazy snapshot did not have the latest commit (b0o/SchemaStore.nvim@1dc606bf07e1419d785e04d6dbb8585987d817cc)

```lua
Error detected while processing command line..User Autocommands for "AstroMasonLspSetup":
Error executing lua callback: /home/maxime/.config/nvim/lua/astronvim/utils/lsp.lua:350: attempt to index field 'yaml' (a nil value)
stack traceback:
        /home/maxime/.config/nvim/lua/astronvim/utils/lsp.lua:350: in function 'config'
        /home/maxime/.config/nvim/lua/astronvim/utils/lsp.lua:85: in function </home/maxime/.config/nvim/lua/astronvim/utils/lsp.lua:78>
        vim/shared.lua: in function 'tbl_map'
        /home/maxime/.config/nvim/lua/plugins/configs/lspconfig.lua:27: in function </home/maxime/.config/nvim/lua/plugins/configs/lspconfig.lua:26>
        [C]: in function 'nvim_exec_autocmds'
        /home/maxime/.config/nvim/lua/astronvim/utils/init.lua:68: in function </home/maxime/.config/nvim/lua/astronvim/utils/init.lua:68>
```

Tested and working (I have a record of being terrible at that, but I'm confident this time :sweat_smile:)