### PR TITLE
feat(alpha): added startup time to alpha

### DIFF
--- a/lua/plugins/alpha.lua
+++ b/lua/plugins/alpha.lua
@@ -28,9 +28,16 @@ return {
       button("LDR S l", "  Last Session  "),
     }
 
-    dashboard.section.footer.val =
-      { " ", " ", " ", "AstroNvim loaded " .. require("lazy").stats().count .. " plugins " }
-    dashboard.section.footer.opts.hl = "DashboardFooter"
+    vim.api.nvim_create_autocmd("UIEnter", {
+      callback = function()
+        local stats = require("lazy").stats()
+        local ms = (math.floor(stats.startuptime * 100 + 0.5) / 100)
+
+        dashboard.section.footer.val =
+          { " ", " ", " ", "AstroNvim loaded " .. stats.count .. " plugins   in " .. ms .. "ms" }
+        dashboard.section.footer.opts.hl = "DashboardFooter"
+      end,
+    })
 
     dashboard.config.layout[1].val = vim.fn.max { 2, vim.fn.floor(vim.fn.winheight(0) * 0.2) }
     dashboard.config.layout[3].val = 5


### PR DESCRIPTION
I think adding the startup time to the default configuration might be a nice feature.

The code snippet is based on LazyVim and has been adapted by @luxus & @jay-babu and shared in the [AstroNvim discord](https://discord.com/channels/939594913560031363/1056415608968855572/1078643025472917516).

It looks like this:
<img width="339" alt="image" src="https://user-images.githubusercontent.com/57495944/225310550-7cd2e711-958f-49a9-ae1a-7166ccb5fdba.png">

