### PR TITLE
feat(buffer): Add nav_to function

### DIFF
--- a/lua/astronvim/utils/buffer.lua
+++ b/lua/astronvim/utils/buffer.lua
@@ -57,6 +57,12 @@ function M.nav(n)
   end
 end
 
+--- Navigate to a specific buffer by its position in the bufferline
+-- @param tabnr the position of the buffer to navigate to
+function M.nav_to(tabnr)
+  vim.cmd.b(vim.t.bufs[tabnr])
+end
+
 --- Close a given buffer
 -- @param bufnr? the buffer number to close or the current buffer if not provided
 -- @param force? whether or not to foce close the buffers or confirm changes (default: false)

--- a/lua/astronvim/utils/buffer.lua
+++ b/lua/astronvim/utils/buffer.lua
@@ -59,9 +59,7 @@ end
 
 --- Navigate to a specific buffer by its position in the bufferline
 -- @param tabnr the position of the buffer to navigate to
-function M.nav_to(tabnr)
-  vim.cmd.b(vim.t.bufs[tabnr])
-end
+function M.nav_to(tabnr) vim.cmd.b(vim.t.bufs[tabnr]) end
 
 --- Close a given buffer
 -- @param bufnr? the buffer number to close or the current buffer if not provided


### PR DESCRIPTION
Adds a function which allows navigating directly to a buffer by its position in the heirline buffer list (this differs from the buffer number itself!).

The modern equivalent of `BufferLineGoTo`.

Allows mappings like the following to be created:

```
["<leader>b1"] = { function() require("astronvim.utils.buffer").nav_to(1) end, desc = "Go to Buffer 1" }
```

or even (courtesy of @mehalter)

```
["<Tab>"] = { function() require("astronvim.utils.buffer").nav_to(vim.v.count) end, desc = "Go to Buffer" }
```