### PR TITLE
fix(updater): fallback to "unknown" version as last resort

### DIFF
--- a/lua/astronvim/utils/updater.lua
+++ b/lua/astronvim/utils/updater.lua
@@ -76,7 +76,7 @@ end
 -- @param quiet boolean to quietly execute or send a notification
 -- @return the current AstroNvim version string
 function M.version(quiet)
-  local version = astronvim.install.version or git.current_version(false)
+  local version = astronvim.install.version or git.current_version(false) or "unknown"
   if astronvim.updater.options.channel ~= "stable" then version = ("nightly (%s)"):format(version) end
   if version and not quiet then notify("Version: " .. version) end
   return version


### PR DESCRIPTION
Fallback to "unknown" version if `astronvim_installation.version` is not provided and the `.git` directory is not available to allow `:checkhealth astronvim` to return.

Before:

```
astronvim: require("astronvim.health").check()
========================================================================
  - ERROR: Failed to run healthcheck for "astronvim" plugin. Exception:
    function health#check, line 20
    Vim(eval):E5108: Error executing lua /home/maxime/.config/nvim/lua/astronvim/health.lua:6: attempt to concatenate a nil value
    stack traceback:
    /home/maxime/.config/nvim/lua/astronvim/health.lua:6: in function 'check'
    [string "luaeval()"]:1: in main chunk
```

After:

```
astronvim: require("astronvim.health").check()
========================================================================
## AstroNvim
  - INFO: AstroNvim Version: unknown
  - INFO: Neovim Version: v0.8.1
  - OK: Using stable Neovim >= 0.8.0
  - OK: `git` is installed: Used for core functionality such as updater and plugin management
  - OK: `xdg-open` is installed: Used for `gx` mapping for opening files with system opener (Optional)
  - OK: `lazygit` is installed: Used for mappings to pull up git TUI (Optional)
  - OK: `node` is installed: Used for mappings to pull up node REPL (Optional)
  - OK: `gdu` is installed: Used for mappings to pull up disk usage analyzer (Optional)
  - OK: `btm` is installed: Used for mappings to pull up system monitor (Optional)
  - OK: `python` is installed: Used for mappings to pull up python REPL (Optional)
```