### PR TITLE
fix(status): add redraw execution to macro_recording

### DIFF
--- a/lua/astronvim/utils/status.lua
+++ b/lua/astronvim/utils/status.lua
@@ -453,6 +453,7 @@ function M.provider.macro_recording(opts)
   return function()
     local register = vim.fn.reg_recording()
     if register ~= "" then register = opts.prefix .. register end
+    vim.cmd "redrawstatus"
     return M.utils.stylize(register, opts)
   end
 end


### PR DESCRIPTION
Fixes the delay in the macro_recording provider you can run `redrawstatus`.