### PR TITLE
fix(utils): add nil check to sbar[i] calculation

### DIFF
--- a/lua/astronvim/utils/status.lua
+++ b/lua/astronvim/utils/status.lua
@@ -552,7 +552,9 @@ function M.provider.scrollbar(opts)
     local curr_line = vim.api.nvim_win_get_cursor(0)[1]
     local lines = vim.api.nvim_buf_line_count(0)
     local i = math.floor((curr_line - 1) / lines * #sbar) + 1
-    return M.utils.stylize(string.rep(sbar[i], 2), opts)
+    if sbar[i] ~= nil then
+      return M.utils.stylize(string.rep(sbar[i], 2), opts)
+    end
   end
 end
 


### PR DESCRIPTION
I will preface this PR by saying I know very little lua and nothing about how the AstroNvim repo works.

Since the v3 update, when I exit nvim, I intermittently receive the below error. It seems to happen when I've been in a file for a longer period of time. If I open nvim in a file and close within 5s, the error never happens. I don't know the cause.

```
Error executing vim.schedule lua callback: /home/mark/.config/nvim/lua/astronvim/utils/status.lua:1065: Vim:E5108: Error executing lua /home/mark/.config/nvim
/lua/astronvim/utils/status.lua:555: bad argument #1 to 'rep' (string expected, got nil)
stack traceback:                                                                                                                                              
        [C]: in function 'rep'                                                                                                                                
        /home/mark/.config/nvim/lua/astronvim/utils/status.lua:555: in function 'provider'
        ...hare/nvim/lazy/heirline.nvim/lua/heirline/statusline.lua:348: in function '_eval'                                                
        ...hare/nvim/lazy/heirline.nvim/lua/heirline/statusline.lua:365: in function '_eval'
        ...hare/nvim/lazy/heirline.nvim/lua/heirline/statusline.lua:365: in function '_eval'                                                
        ...hare/nvim/lazy/heirline.nvim/lua/heirline/statusline.lua:365: in function '_eval'
        ...hare/nvim/lazy/heirline.nvim/lua/heirline/statusline.lua:365: in function '_eval'
        ...hare/nvim/lazy/heirline.nvim/lua/heirline/statusline.lua:440: in function 'eval'
        ...ocal/share/nvim/lazy/heirline.nvim/lua/heirline/init.lua:110: in function <...ocal/share/nvim/lazy/heirline.nvim/lua/heirline/init.lua:105>
        [C]: in function 'redrawstatus'                                        
        /home/mark/.config/nvim/lua/astronvim/utils/status.lua:1065: in function ''                                                         
        vim/_editor.lua: in function <vim/_editor.lua:0>
stack traceback:                                                               
        [C]: in function 'redrawstatus'
        /home/mark/.config/nvim/lua/astronvim/utils/status.lua:1065: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>ls
```

Adding the nil check prevents the error from occurring when I exit nvim. Not sure if this is the best solution or if this even needs a solution.