### PR TITLE
LSP - Toggle Semantic Token highlights

### DIFF
--- a/lua/astronvim/utils/lsp.lua
+++ b/lua/astronvim/utils/lsp.lua
@@ -288,6 +288,22 @@ M.on_attach = function(client, bufnr)
     }
   end
 
+  if capabilities.semanticTokensProvider and vim.lsp["semantic_tokens"] ~= nil then
+    local semantic_highlight_on = true
+    lsp_mappings.n["<leader>uY"] = {
+      function()
+        if semantic_highlight_on then
+          vim.lsp.semantic_tokens.stop(bufnr, client.id)
+          semantic_highlight_on = false
+        else
+          vim.lsp.semantic_tokens.start(bufnr, client.id)
+          semantic_highlight_on = true
+        end
+      end,
+      desc = "Toggle LSP semantic highlight (buffer)",
+    }
+  end
+
   if is_available "telescope.nvim" then -- setup telescope mappings if available
     if lsp_mappings.n.gd then lsp_mappings.n.gd[1] = function() require("telescope.builtin").lsp_definitions() end end
     if lsp_mappings.n.gI then

--- a/lua/astronvim/utils/lsp.lua
+++ b/lua/astronvim/utils/lsp.lua
@@ -23,6 +23,23 @@ local setup_handlers = user_opts("lsp.setup_handlers", {
   function(server, opts) require("lspconfig")[server].setup(opts) end,
 })
 
+local toggle_semantic_highlights = function(bufnr)
+  if vim.b.semantic_highlight_enabled == nil then vim.b.semantic_highlight_enabled = true end
+
+  local lsp_clients = vim.lsp.get_active_clients()
+  for _, client in ipairs(lsp_clients) do
+    if client.server_capabilities["semanticTokensProvider"] ~= nil then
+      if vim.b.semantic_highlight_enabled then
+        vim.lsp.semantic_tokens.stop(bufnr, client.id)
+      else
+        vim.lsp.semantic_tokens.start(bufnr, client.id)
+      end
+    end
+  end
+
+  vim.b.semantic_highlight_enabled = not vim.b.semantic_highlight_enabled
+end
+
 M.diagnostics = { [0] = {}, {}, {}, {} }
 
 M.setup_diagnostics = function(signs)
@@ -289,17 +306,8 @@ M.on_attach = function(client, bufnr)
   end
 
   if capabilities.semanticTokensProvider and vim.lsp["semantic_tokens"] ~= nil then
-    local semantic_highlight_on = true
     lsp_mappings.n["<leader>uY"] = {
-      function()
-        if semantic_highlight_on then
-          vim.lsp.semantic_tokens.stop(bufnr, client.id)
-          semantic_highlight_on = false
-        else
-          vim.lsp.semantic_tokens.start(bufnr, client.id)
-          semantic_highlight_on = true
-        end
-      end,
+      function() toggle_semantic_highlights(bufnr) end,
       desc = "Toggle LSP semantic highlight (buffer)",
     }
   end


### PR DESCRIPTION
LSP semantic tokens are not perfect; bugs have been reported. Allow user to toggle semantic token highlights. Also very useful for theme/plugin development.

Neovim 0.9 introduces support for LSP semantic tokens. Users will experience the effect of LSP servers sending incorrect semantic tokens, resulting in incorrect syntax highlighting.

After lengthy discussions with @mehalter, we have seen that it is possible to handle these bugs accordingly, but agreed that we _should not_.
Instead, my suggestion is to provide the ability to disable/toggle semantic tokens as a whole, whether for a buffer, a language server, or globally.
AstroNvim already gives the user the ability to disable semantic tokens globally or per language server via the `lsp.on_attach` user option.
This change addresses toggling semantic token highlighting for a buffer.

![Screen Recording 2023-03-20 at 9 26 29 PM](https://user-images.githubusercontent.com/25430772/226500445-5f2331f6-1dfd-4d21-9664-68ba7903e7bc.gif)
