### PR TITLE
fix(bootstrap): "improved" config directory detection respects backslash

### DIFF
--- a/lua/astronvim/bootstrap.lua
+++ b/lua/astronvim/bootstrap.lua
@@ -13,7 +13,7 @@ _G.astronvim = {}
 astronvim.install = _G["astronvim_installation"] or { home = vim.fn.stdpath "config" }
 astronvim.supported_configs = { astronvim.install.home }
 --- external astronvim configuration folder
-astronvim.install.config = vim.fn.stdpath("config"):gsub("[^/]+$", "astronvim")
+astronvim.install.config = vim.fn.stdpath("config"):gsub("[^/\\]+$", "astronvim")
 -- check if they are the same, protects against NVIM_APPNAME use for isolated install
 if astronvim.install.home ~= astronvim.install.config then
   vim.opt.rtp:append(astronvim.install.config)


### PR DESCRIPTION
Looks like the new config directory detection did not take into account that the `vim.fn.stdpath` will return a path with backslashes on Windows. I added the backslash to the pattern.