### PR TITLE
Fix: error in utils/buffer/is_valid trying to access invalid buffer on specific conditions

### DIFF
--- a/lua/astronvim/utils/buffer.lua
+++ b/lua/astronvim/utils/buffer.lua
@@ -15,7 +15,7 @@ local M = {}
 -- @return true if the buffer is valid or false
 function M.is_valid(bufnr)
   if not bufnr or bufnr < 1 then return false end
-  return vim.bo[bufnr].buflisted and vim.api.nvim_buf_is_valid(bufnr)
+  return vim.api.nvim_buf_is_valid(bufnr) and vim.bo[bufnr].buflisted
 end
 
 --- Move the current buffer tab n places in the bufferline


### PR DESCRIPTION
If you try to access `vim.bo[bufnr].buflisted` of an invalid `bufnr` the editor will throw an error. This happens when special buffers are defined but are not valid.

Putting `vim.api.nvim_buf_is_valid(bufnr)` first in the condition makes sure the call to `vim.bo` doesn't throw an error.

# How to reproduce the error?

* Open nvim (without parameters) and load any file (type is irrelevant)
* Close nvim
* Open nvim  (without parameters) and use `Ctrl-o` twice. 

## Why `Ctrl-o` twice?

This is an easy way to jump back directly to the last file you were modifying.