### PR TITLE
fix(utils): system_open in neotree on windows, use "cmd.exe /K explorer" instead of "explorer"

### DIFF
--- a/lua/astronvim/utils/init.lua
+++ b/lua/astronvim/utils/init.lua
@@ -94,14 +94,14 @@ end
 function M.system_open(path)
   local cmd
   if vim.fn.has "win32" == 1 and vim.fn.executable "explorer" == 1 then
-    cmd = "explorer"
+    cmd = {"cmd.exe", "/K", "explorer"}
   elseif vim.fn.has "unix" == 1 and vim.fn.executable "xdg-open" == 1 then
-    cmd = "xdg-open"
+    cmd = {"xdg-open"}
   elseif (vim.fn.has "mac" == 1 or vim.fn.has "unix" == 1) and vim.fn.executable "open" == 1 then
-    cmd = "open"
+    cmd = {"open"}
   end
   if not cmd then M.notify("Available system opening tool not found!", "error") end
-  vim.fn.jobstart({ cmd, path or vim.fn.expand "<cfile>" }, { detach = true })
+  vim.fn.jobstart(vim.fn.extend(cmd, {path or vim.fn.expand "<cfile>" }), { detach = true })
 end
 
 -- term_details can be either a string for just a command or

--- a/lua/astronvim/utils/init.lua
+++ b/lua/astronvim/utils/init.lua
@@ -94,14 +94,14 @@ end
 function M.system_open(path)
   local cmd
   if vim.fn.has "win32" == 1 and vim.fn.executable "explorer" == 1 then
-    cmd = {"cmd.exe", "/K", "explorer"}
+    cmd = { "cmd.exe", "/K", "explorer" }
   elseif vim.fn.has "unix" == 1 and vim.fn.executable "xdg-open" == 1 then
-    cmd = {"xdg-open"}
+    cmd = { "xdg-open" }
   elseif (vim.fn.has "mac" == 1 or vim.fn.has "unix" == 1) and vim.fn.executable "open" == 1 then
-    cmd = {"open"}
+    cmd = { "open" }
   end
   if not cmd then M.notify("Available system opening tool not found!", "error") end
-  vim.fn.jobstart(vim.fn.extend(cmd, {path or vim.fn.expand "<cfile>" }), { detach = true })
+  vim.fn.jobstart(vim.fn.extend(cmd, { path or vim.fn.expand "<cfile>" }), { detach = true })
 end
 
 -- term_details can be either a string for just a command or


### PR DESCRIPTION
Fix for #1710 