### PR TITLE
Custom Session Management with Resession.nvim

### DIFF
--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -179,6 +179,16 @@ if is_available "alpha-nvim" then
   })
 end
 
+if is_available "resession.nvim" then
+  autocmd("VimLeavePre", {
+    callback = function()
+      local save = require("resession").save
+      save "Last Session"
+      save(vim.fn.getcwd(), { dir = "dirsession", notify = false })
+    end,
+  })
+end
+
 if is_available "neo-tree.nvim" then
   autocmd("BufEnter", {
     desc = "Open Neo-Tree on startup with directory",

--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -184,6 +184,18 @@ if is_available "neovim-session-manager" then
   maps.n["<leader>S."] =
     { "<cmd>SessionManager! load_current_dir_session<cr>", desc = "Load current directory session" }
 end
+if is_available "resession.nvim" then
+  maps.n["<leader>S"] = sections.S
+  maps.n["<leader>Sl"] = { function() require("resession").load "Last Session" end, desc = "Load last session" }
+  maps.n["<leader>Ss"] = { function() require("resession").save() end, desc = "Save this session" }
+  maps.n["<leader>St"] = { function() require("resession").save_tab() end, desc = "Save this tab's session" }
+  maps.n["<leader>Sd"] = { function() require("resession").delete() end, desc = "Delete a session" }
+  maps.n["<leader>Sf"] = { function() require("resession").load() end, desc = "Load a session" }
+  maps.n["<leader>S."] = {
+    function() require("resession").load(vim.fn.getcwd(), { dir = "dirsession" }) end,
+    desc = "Load current directory session",
+  }
+end
 
 -- Package Manager
 if is_available "mason.nvim" then

--- a/lua/plugins/core.lua
+++ b/lua/plugins/core.lua
@@ -4,7 +4,21 @@ return {
   { "famiu/bufdelete.nvim", cmd = { "Bdelete", "Bwipeout" } },
   { "max397574/better-escape.nvim", event = "InsertCharPre", opts = { timeout = 300 } },
   { "NMAC427/guess-indent.nvim", event = "User AstroFile", config = require "plugins.configs.guess-indent" },
-  { "Shatur/neovim-session-manager", event = "BufWritePost", cmd = "SessionManager" },
+  { -- TODO: REMOVE neovim-session-manager with AstroNvim v4
+    "Shatur/neovim-session-manager",
+    event = "BufWritePost",
+    cmd = "SessionManager",
+    enabled = not vim.g.resession_enabled,
+  },
+  {
+    "stevearc/resession.nvim",
+    enabled = vim.g.resession_enabled,
+    opts = {
+      buf_filter = function(bufnr) return require("astronvim.utils.buffer").is_valid(bufnr) end,
+      tab_buf_filter = function(tabpage, bufnr) return vim.tbl_contains(vim.t[tabpage].bufs, bufnr) end,
+      extensions = { astronvim = {} },
+    },
+  },
   { "s1n7ax/nvim-window-picker", opts = { use_winbar = "smart" } },
   {
     "mrjones2014/smart-splits.nvim",

--- a/lua/resession/extensions/astronvim.lua
+++ b/lua/resession/extensions/astronvim.lua
@@ -1,0 +1,32 @@
+local M = {}
+
+M.on_save = function()
+  -- initiate astronvim data
+  local data = { bufnrs = {}, tabs = {} }
+
+  -- save tab scoped buffers and buffer numbers from buffer name
+  for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+    data.tabs[tabpage] = vim.t[tabpage].bufs
+    for _, bufnr in ipairs(data.tabs[tabpage]) do
+      data.bufnrs[vim.api.nvim_buf_get_name(bufnr)] = bufnr
+    end
+  end
+
+  return data
+end
+
+M.on_load = function(data)
+  -- create map from old buffer numbers to new buffer numbers
+  local new_bufnrs = {}
+  vim.print(vim.api.nvim_list_bufs())
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    local bufname = vim.api.nvim_buf_get_name(bufnr)
+    if bufname and bufname ~= "" then new_bufnrs[data.bufnrs[bufname]] = bufnr end
+  end
+  -- build new tab scoped buffer lists
+  for tabpage, tabs in pairs(data.tabs) do
+    vim.t[tabpage].bufs = vim.tbl_map(function(bufnr) return new_bufnrs[bufnr] end, tabs)
+  end
+end
+
+return M


### PR DESCRIPTION
This adds a new feature in a non-breaking way to use [`resession.nvim`](https://github.com/stevearc/resession.nvim/). We have made this toggle-able through `vim.g.resession_enabled = true` to enable the experimental feature. This comes with a lot more flexibility and allows us to use extensions to appropriately restore sessions with multiple tabs with our tab-scoped buffer management.

The goal is to remove `neovim-session-management` as the default session manager in AstroNvim v4 and just use `resession.nvim`. This does require lots of testing and the feature is experimental/probably buggy.