### PR TITLE
fix(buffer): fix close without bufdelete

### DIFF
--- a/lua/astronvim/utils/buffer.lua
+++ b/lua/astronvim/utils/buffer.lua
@@ -69,7 +69,7 @@ function M.close(bufnr, force)
   if require("astronvim.utils").is_available "bufdelete.nvim" then
     require("bufdelete").bufdelete(bufnr, force)
   else
-    vim.cmd((force and "bd!" or "confirm bd") .. bufnr)
+    vim.cmd((force and "bd!" or "confirm bd") .. (bufnr == nil and "" or bufnr))
   end
 end
 


### PR DESCRIPTION
`<leader>c` with disabled bufdelete plugin leads to error messages:
```
E5108: Error executing lua: .../.config/nvim/lua/astronvim/utils/buffer.lua:72: attempt to concatenate local 'bufnr' (a nil value)                               
stack traceback:
        .../.config/nvim/lua/astronvim/utils/buffer.lua:72: in function 'close'
        .../.config/nvim/lua/astronvim/mappings.lua:49: in function <.../.config/nvim/lua/astronvim/mappings.lua:49>
```

This behavior is fixed by guarding the nil `bufnr` value.