### PR TITLE
feat(ui): toggle virtual_lines

### DIFF
--- a/lua/astronvim/utils/lsp.lua
+++ b/lua/astronvim/utils/lsp.lua
@@ -45,12 +45,12 @@ M.setup_diagnostics = function(signs)
     -- diagnostics off
     [0] = utils.extend_tbl(
       default_diagnostics,
-      { underline = false, virtual_text = false, signs = false, update_in_insert = false }
+      { underline = false, virtual_lines = false, virtual_text = false, signs = false, update_in_insert = false }
     ),
     -- status only
-    utils.extend_tbl(default_diagnostics, { virtual_text = false, signs = false }),
-    -- virtual text off, signs on
-    utils.extend_tbl(default_diagnostics, { virtual_text = false }),
+    utils.extend_tbl(default_diagnostics, { virtual_lines = false, virtual_text = false, signs = false }),
+    -- virtual lines/text off, signs on
+    utils.extend_tbl(default_diagnostics, { virtual_lines = false, virtual_text = false }),
     -- all diagnostics on
     default_diagnostics,
   }

--- a/lua/astronvim/utils/ui.lua
+++ b/lua/astronvim/utils/ui.lua
@@ -48,7 +48,7 @@ function M.toggle_diagnostics()
   elseif vim.g.diagnostics_mode == 1 then
     ui_notify "only status diagnostics"
   elseif vim.g.diagnostics_mode == 2 then
-    ui_notify "virtual text off"
+    ui_notify "virtual lines/text off"
   else
     ui_notify "all diagnostics on"
   end


### PR DESCRIPTION
Allow user to toggle `virtual_lines` with the same experience as `virtual_text`

For users who do use `virtual_lines`, this feature has been missing from AstroNvim, however it fits nicely into our existing toggles for `virtual_text` with no apparent side-effects.

![toggle-virtual-lines](https://user-images.githubusercontent.com/25430772/233872518-de8ab026-474e-4b84-95e1-04d6d313c0c6.gif)
