### PR TITLE
chore(gitignore): ignore MacOS System files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ plugin
 ftplugin
 spell
 .luarc.json
+.DS_Store


### PR DESCRIPTION
Description:
MacOS System files pollutes `git status` output. Ignoring these files helps (:
