### PR TITLE
fix(plugins): don't load git signs for gitcommit

### DIFF
--- a/lua/plugins/git.lua
+++ b/lua/plugins/git.lua
@@ -1,7 +1,6 @@
 return {
   "lewis6991/gitsigns.nvim",
   enabled = vim.fn.executable "git" == 1,
-  ft = "gitcommit",
   event = "User AstroGitFile",
   opts = {
     signs = {


### PR DESCRIPTION
Bugs Fixed:
- Fixes `(UNKNOWN PLUGIN): Error executing lua: attempt to call a nil value` error message when writing a git commit message using AstroNvim. This was caused by `gitsigns` being loaded for `gitcommit` files, this PR disables that.

Other:

I don't think there is any use case where `gitsigns` is required for a `gitcommit` file, since the commit message is not in a file tracked by git. Please correct me if I'm wrong.
