### PR TITLE
Fix neo-tree empty folder icon with nerdfont v3

### DIFF
--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -24,6 +24,7 @@ return {
         folder_closed = get_icon "FolderClosed",
         folder_open = get_icon "FolderOpen",
         folder_empty = get_icon "FolderEmpty",
+        folder_empty_open = get_icon "FolderEmpty",
         default = get_icon "DefaultFile",
       },
       modified = { symbol = get_icon "FileModified" },


### PR DESCRIPTION
There was a missing key in the config for neo-tree causing empty folders to render the default char shown in the commit below.

https://github.com/nvim-neo-tree/neo-tree.nvim/pull/600/commits/465add19fc88e0257d06da7d5c3ca75c51449f0f#diff-b2cb9452bc9983e124579b119e5d1e01dbe8627f638852ef8ae2ec049c84b920