### PR TITLE
 feat(treesitter): Option added → auto_install = true

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -27,6 +27,7 @@ return {
     indent = { enable = true },
     autotag = { enable = true },
     context_commentstring = { enable = true, enable_autocmd = false },
+    auto_install = true,
   },
   config = require "plugins.configs.nvim-treesitter",
 }


### PR DESCRIPTION
This option ensures treesitter always has the necessary language parser when opening a new buffer.

If it is not present, it will install it without asking the user.