### PR TITLE
fix: load session with error table index is nil

### DIFF
--- a/lua/resession/extensions/astronvim.lua
+++ b/lua/resession/extensions/astronvim.lua
@@ -20,7 +20,9 @@ M.on_load = function(data)
   local new_bufnrs = {}
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     local bufname = vim.api.nvim_buf_get_name(bufnr)
-    if bufname and bufname ~= "" then new_bufnrs[data.bufnrs[bufname]] = bufnr end
+    if bufname and bufname ~= "" then
+      if data.bufnrs[bufname] ~= nil then new_bufnrs[data.bufnrs[bufname]] = bufnr end
+    end
   end
   -- build new tab scoped buffer lists
   for tabpage, tabs in pairs(data.tabs) do


### PR DESCRIPTION
when dat.bufnrs[buffname] is nil, cause error table index is nil.