### PR TITLE
fix cmp menu width when using Rust

### DIFF
--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -46,7 +46,9 @@ return {
         preselect = cmp.PreselectMode.None,
         formatting = {
           fields = { "kind", "abbr", "menu" },
-          format = lspkind_status_ok and lspkind.cmp_format(utils.plugin_opts "lspkind.nvim") or nil,
+          format = lspkind_status_ok and lspkind.cmp_format(
+            vim.tbl_deep_extend("force", utils.plugin_opts "lspkind.nvim", { menu = {} })
+          ) or nil,
         },
         snippet = {
           expand = function(args) luasnip.lsp_expand(args.body) end,


### PR DESCRIPTION
fix cmp menu width when using Rust

see : https://github.com/hrsh7th/nvim-cmp/issues/1154
