### PR TITLE
fix(lsp) On writing a buffer with no filetype, reload it so LSP kicks in.

### DIFF
--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -59,6 +59,17 @@ autocmd("BufDelete", {
   end,
 })
 
+autocmd("BufWritePre", {
+  desc = "When writing a buffer with no filetype, reload it so lsp kicks in.",
+  group = bufferline_group,
+  callback = function()
+    if vim.bo.buftype == '' then
+      local delay_ms = 100
+      vim.defer_fn(function() vim.cmd('edit') end, delay_ms)
+    end
+  end,
+})
+
 autocmd({ "VimEnter", "FileType", "BufEnter", "WinEnter" }, {
   desc = "URL Highlighting",
   group = augroup("highlighturl", { clear = true }),


### PR DESCRIPTION
Maybe you can think a more reliable solution but this fixes the issue for now.

## How to test this PR

* Create a new buffer with `:new`
* Write something and save it as `myfile.lua` (or any other filetype)
* Now LSP and heirline LSP indicator will kick in correctly.