### PR TITLE
fix(heirline) VeryLazy instead of BufEnter

### DIFF
--- a/lua/plugins/heirline.lua
+++ b/lua/plugins/heirline.lua
@@ -1,6 +1,6 @@
 return {
   "rebelot/heirline.nvim",
-  event = "BufEnter",
+  event = "VeryLazy",
   opts = function()
     local status = require "astronvim.utils.status"
     return {


### PR DESCRIPTION
Please feel free to ignore this PR: I've noticed using `BufEnter` instead of `VeryLazy` can cause issues in some border scenarios on component.lsp() where the condition.lsp_attached() report incorrectly. When using a colorcheme other than AstroTheme.

![screenshot_2023-06-28_14-10-17_404151422](https://github.com/AstroNvim/AstroNvim/assets/3357792/fdeeb5e8-0f1d-4786-8f90-4aca258701eb)

The image is AstroNvim nightly unchanged, using tokyonight-night.

## How to repro
To reproduce it 100%, open `:term` and run `nvim somefile`. But it can manifest on other scenarios.

My hypothesis is AstroTheme somehow hides stack trace errors from the UI, as it is the only theme I've found where the error doesn't manifest. 