### PR TITLE
Only build LuaSnip if NOT on Windows

### DIFF
--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -1,6 +1,7 @@
 return {
   {
     "L3MON4D3/LuaSnip",
+    -- `make` is usually not available on Windows systems, so skip the build in case of Windows.
     build = vim.fn.has "win32" ~= 1
         and "echo 'NOTE: jsregexp is optional, so not a big deal if it fails to build\n'; make install_jsregexp"
       or nil,

--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -1,7 +1,7 @@
 return {
   {
     "L3MON4D3/LuaSnip",
-    build = vim.fn.has "win32" ~= 0
+    build = vim.fn.has "win32" ~= 1
         and "echo 'NOTE: jsregexp is optional, so not a big deal if it fails to build\n'; make install_jsregexp"
       or nil,
     dependencies = { "rafamadriz/friendly-snippets" },


### PR DESCRIPTION
`make` is usually available on UNIX systems, but the current check sets the `build` property if `win32` IS PRESENT.
This means that the `build` property is present in the case of Windows, and absent in the case of UNIX.
As a Windows user, I get an error every time I update my plugins, and UNIX users don't get the feature they usually can install correctly.
I updated the check to detect if `win32` is NOT `1`, instead of NOT `0`, so that the `build` property is only present on non-Windows systems.