### PR TITLE
feat(options): add setting to enable git integration for custom worktrees

### DIFF
--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -257,7 +257,28 @@ autocmd({ "BufReadPost", "BufNewFile", "BufWritePost" }, {
   callback = function(args)
     if not (vim.fn.expand "%" == "" or vim.api.nvim_get_option_value("buftype", { buf = args.buf }) == "nofile") then
       astroevent "File"
-      if utils.cmd({ "git", "-C", vim.fn.expand "%:p:h", "rev-parse" }, false) then
+      local function in_worktree()
+        for _, worktree in ipairs(vim.g.git_worktrees) do
+          if
+            utils.cmd({
+              "git",
+              "--work-tree",
+              worktree.toplevel,
+              "--git-dir",
+              worktree.gitdir,
+              "ls-files",
+              "--error-unmatch",
+              vim.fn.expand "%",
+            }, false)
+          then
+            return true
+          end
+        end
+        return false
+      end
+      if
+        utils.cmd({ "git", "-C", vim.fn.expand "%:p:h", "rev-parse" }, false) or vim.g.git_worktrees and in_worktree()
+      then
         astroevent "GitFile"
         vim.api.nvim_del_augroup_by_name "file_user_events"
       end

--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -257,27 +257,10 @@ autocmd({ "BufReadPost", "BufNewFile", "BufWritePost" }, {
   callback = function(args)
     if not (vim.fn.expand "%" == "" or vim.api.nvim_get_option_value("buftype", { buf = args.buf }) == "nofile") then
       astroevent "File"
-      local function in_worktree()
-        for _, worktree in ipairs(vim.g.git_worktrees) do
-          if
-            utils.cmd({
-              "git",
-              "--work-tree",
-              worktree.toplevel,
-              "--git-dir",
-              worktree.gitdir,
-              "ls-files",
-              "--error-unmatch",
-              vim.fn.expand "%",
-            }, false)
-          then
-            return true
-          end
-        end
-        return false
-      end
       if
-        utils.cmd({ "git", "-C", vim.fn.expand "%:p:h", "rev-parse" }, false) or vim.g.git_worktrees and in_worktree()
+        utils.cmd({ "git", "-C", vim.fn.expand "%:p:h", "rev-parse" }, false)
+        or vim.g.git_worktrees
+          and require("astronvim.utils.git").file_worktree(vim.fn.expand "%", vim.g.git_worktrees)
       then
         astroevent "GitFile"
         vim.api.nvim_del_augroup_by_name "file_user_events"

--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -308,8 +308,28 @@ if is_available "toggleterm.nvim" then
   maps.n["<leader>t"] = sections.t
   if vim.fn.executable "lazygit" == 1 then
     maps.n["<leader>g"] = sections.g
-    maps.n["<leader>gg"] = { function() utils.toggle_term_cmd "lazygit" end, desc = "ToggleTerm lazygit" }
-    maps.n["<leader>tl"] = { function() utils.toggle_term_cmd "lazygit" end, desc = "ToggleTerm lazygit" }
+    maps.n["<leader>gg"] = {
+      function()
+        local worktree = vim.g.git_worktrees
+          and require("astronvim.utils.git").file_worktree(vim.fn.expand "%", vim.g.git_worktrees)
+        local lazygit_cmd = worktree
+            and ("lazygit --work-tree=" .. worktree.toplevel .. " --git-dir=" .. worktree.gitdir)
+          or "lazygit"
+        utils.toggle_term_cmd(lazygit_cmd)
+      end,
+      desc = "ToggleTerm lazygit",
+    }
+    maps.n["<leader>tl"] = {
+      function()
+        local worktree = vim.g.git_worktrees
+          and require("astronvim.utils.git").file_worktree(vim.fn.expand "%", vim.g.git_worktrees)
+        local lazygit_cmd = worktree
+            and ("lazygit --work-tree=" .. worktree.toplevel .. " --git-dir=" .. worktree.gitdir)
+          or "lazygit"
+        utils.toggle_term_cmd(lazygit_cmd)
+      end,
+      desc = "ToggleTerm lazygit",
+    }
   end
   if vim.fn.executable "node" == 1 then
     maps.n["<leader>tn"] = { function() utils.toggle_term_cmd "node" end, desc = "ToggleTerm node" }

--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -319,17 +319,7 @@ if is_available "toggleterm.nvim" then
       end,
       desc = "ToggleTerm lazygit",
     }
-    maps.n["<leader>tl"] = {
-      function()
-        local worktree = vim.g.git_worktrees
-          and require("astronvim.utils.git").file_worktree(vim.fn.expand "%", vim.g.git_worktrees)
-        local lazygit_cmd = worktree
-            and ("lazygit --work-tree=" .. worktree.toplevel .. " --git-dir=" .. worktree.gitdir)
-          or "lazygit"
-        utils.toggle_term_cmd(lazygit_cmd)
-      end,
-      desc = "ToggleTerm lazygit",
-    }
+    maps.n["<leader>tl"] = maps.n["<leader>gg"]
   end
   if vim.fn.executable "node" == 1 then
     maps.n["<leader>tn"] = { function() utils.toggle_term_cmd "node" end, desc = "ToggleTerm node" }

--- a/lua/astronvim/options.lua
+++ b/lua/astronvim/options.lua
@@ -63,6 +63,7 @@ local options = astronvim.user_opts("options", {
     lsp_handlers_enabled = true, -- enable or disable default vim.lsp.handlers (hover and signatureHelp)
     semantic_tokens_enabled = true, -- enable or disable LSP semantic tokens on startup
     ui_notifications_enabled = true, -- disable notifications (TODO: rename to  notifications_enabled in AstroNvim v4)
+    git_worktrees = nil, -- enable git integration for custom worktrees (specify a table where each entry is of the form { toplevel = vim.env.HOME, gitdir=vim.env.HOME .. "/.dotfiles" })
   },
   t = vim.t.bufs and vim.t.bufs or { bufs = vim.api.nvim_list_bufs() }, -- initialize buffers for the current tab
 })

--- a/lua/astronvim/utils/git.lua
+++ b/lua/astronvim/utils/git.lua
@@ -186,4 +186,27 @@ function git.pretty_changelog(commits)
   return changelog
 end
 
+--- Get the first worktree that a file belongs to
+---@param file string the file to check
+---@param worktrees table<string, string>[] an array like table of worktrees with entries `toplevel` and `gitdir`
+---@return table<string, string>|nil # a table specifying the `toplevel` and `gitdir` of a worktree or nil if not found
+function git.file_worktree(file, worktrees)
+  for _, worktree in ipairs(worktrees) do
+    if
+      require("astronvim.utils").cmd({
+        "git",
+        "--work-tree",
+        worktree.toplevel,
+        "--git-dir",
+        worktree.gitdir,
+        "ls-files",
+        "--error-unmatch",
+        file,
+      }, false)
+    then
+      return worktree
+    end
+  end
+end
+
 return git

--- a/lua/plugins/git.lua
+++ b/lua/plugins/git.lua
@@ -12,5 +12,6 @@ return {
       changedelete = { text = get_icon "GitSign" },
       untracked = { text = get_icon "GitSign" },
     },
+    worktrees = vim.g.git_worktrees,
   },
 }


### PR DESCRIPTION
Many users (myself included) like tracking their dotfiles in bare git repos which rely on setting a custom worktree to work. Unfortunately, this also means that while editing dotfiles, it's not possible to see git diffs in the gutter or open lazygit in the correct repository as without a `.git` folder it is difficult to know whether a file is being tracked by a bare repo or not.

This PR adds git integration when editing files within custom worktrees, allowing toggleterm and gitsigns gutter highlighting to work as you would expect them to. It also fixes the AstroGitFile event to trigger when a file within a custom worktree is opened, allowing plugins like gitsigns to propely lazy load. 

This functionality is opt-in, so those who don't rely on custom worktrees won't notice anything.

To enable it, set the global option git_worktrees to an array-like table, where each entry represents a worktree with entries `toplevel` and `gitdir`.  This mirrors a similar configuration option in gitsigns (lewis6991/gitsigns.nvim/pull/600). For example, if you have a bare git repo located at ~/.cfg, you can enable git integration for it by setting the following in the AstroNvim global options table:
```lua
git_worktrees = { { toplevel = vim.env.HOME, gitdir = vim.env.HOME .. "/.cfg" } }, -- allow custom git_worktrees to be detected
```