### PR TITLE
fix(ui): notifications appearing on top in unintended situations

### DIFF
--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -52,7 +52,7 @@ return {
     init = function() require("astronvim.utils").load_plugin_with_func("nvim-notify", vim, "notify") end,
     opts = {
       on_open = function(win)
-        vim.api.nvim_win_set_config(win, { zindex = 150 })
+        vim.api.nvim_win_set_config(win, { zindex = 175 })
         -- close notification immediately if notifications disabled
         if not vim.g.ui_notifications_enabled then vim.api.nvim_win_close(win, true) end
       end,

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -52,7 +52,7 @@ return {
     init = function() require("astronvim.utils").load_plugin_with_func("nvim-notify", vim, "notify") end,
     opts = {
       on_open = function(win)
-        vim.api.nvim_win_set_config(win, { zindex = 1000 })
+        vim.api.nvim_win_set_config(win, { zindex = 150 })
         -- close notification immediately if notifications disabled
         if not vim.g.ui_notifications_enabled then vim.api.nvim_win_close(win, true) end
       end,


### PR DESCRIPTION
This fixes an issue where notifications were obscuring UI elements of plugins like [Noice](https://github.com/folke/noice.nvim/blob/main/lua/noice/config/views.lua
).