### PR TITLE
fix(utils): set alpha cursor in a better position

### DIFF
--- a/lua/astronvim/utils/init.lua
+++ b/lua/astronvim/utils/init.lua
@@ -213,7 +213,7 @@ function M.alpha_button(sc, txt)
       position = "center",
       text = txt,
       shortcut = sc,
-      cursor = 5,
+      cursor = -2,
       width = 36,
       align_shortcut = "right",
       hl = "DashboardCenter",


### PR DESCRIPTION
In the `alpha_button` function, its return has an `opts` table that defines the position of the cursor. I changed it to the beginning of the button. Before it was in the middle of the text.