### PR TITLE
fix(utils): allow terminals opened by toggle_term_cmd to dynamically resize

### DIFF
--- a/lua/astronvim/utils/init.lua
+++ b/lua/astronvim/utils/init.lua
@@ -166,7 +166,7 @@ end
 function M.toggle_term_cmd(opts)
   local terms = astronvim.user_terminals
   -- if a command string is provided, create a basic table for Terminal:new() options
-  if type(opts) == "string" then opts = { cmd = opts, hidden = true } end
+  if type(opts) == "string" then opts = { cmd = opts, hidden = false } end
   local num = vim.v.count > 0 and vim.v.count or 1
   -- if terminal doesn't exist yet, create it
   if not terms[opts.cmd] then terms[opts.cmd] = {} end


### PR DESCRIPTION
For some reason, terminals opened by [toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim) are not dynamically resized when the terminal window is resized or the font size is changed even though normal floating terminals are. After skimming through the docs, I think may be a bug with toggleterm, but setting `hidden=true` resolves this issue.

As a consequence, this changes the behavior of the `:ToggleTerm` command to toggle the last opened floating terminal, including those opened with a custom command. But honestly, I actually prefer this behavior as I can easily toggle back to my main neovim window from lazygit with `F7` or `<C-'>` without having to constantly quit and reopen it, losing progress. (This is kind of embarassing, but I couldn't figure out a way to switch back as keybindings in lazygit conflict with default neovim bindings). 

This means that to switch back to an existing floating term, you'll need to use a command like `:1ToggleTerm`. But as quitting out of lazygit makes it so that the ToggleTerm command toggles the previous active terminal, I think this is a convenient "side effect". 