### PR TITLE
feat(utils): add option to disable telescope integration for lsp keymaps

### DIFF
--- a/lua/astronvim/options.lua
+++ b/lua/astronvim/options.lua
@@ -64,6 +64,7 @@ local options = astronvim.user_opts("options", {
     semantic_tokens_enabled = true, -- enable or disable LSP semantic tokens on startup
     ui_notifications_enabled = true, -- disable notifications (TODO: rename to  notifications_enabled in AstroNvim v4)
     git_worktrees = nil, -- enable git integration for detached worktrees (specify a table where each entry is of the form { toplevel = vim.env.HOME, gitdir=vim.env.HOME .. "/.dotfiles" })
+    telescope_lsp_integration_enabled = true, -- enable telescope integration for lsp keymaps
   },
   t = vim.t.bufs and vim.t.bufs or { bufs = vim.api.nvim_list_bufs() }, -- initialize buffers for the current tab
 })

--- a/lua/astronvim/utils/lsp.lua
+++ b/lua/astronvim/utils/lsp.lua
@@ -331,7 +331,7 @@ M.on_attach = function(client, bufnr)
     }
   end
 
-  if is_available "telescope.nvim" then -- setup telescope mappings if available
+  if vim.g.telescope_lsp_integration_enabled and is_available "telescope.nvim" then -- setup telescope mappings if available
     if lsp_mappings.n.gd then lsp_mappings.n.gd[1] = function() require("telescope.builtin").lsp_definitions() end end
     if lsp_mappings.n.gI then
       lsp_mappings.n.gI[1] = function() require("telescope.builtin").lsp_implementations() end


### PR DESCRIPTION
I prefer to use things like `go to reference` with the default window and `bqf` preview, this pr adds handy way to disable telescope integration, which is still enabled by default

<img width="1728" alt="image" src="https://github.com/AstroNvim/AstroNvim/assets/67468725/0a40fdfd-381d-4388-9ef6-1d530797c80a">
