### PR TITLE
fix(mappings): use git root of current file for git telescope mappings

### DIFF
--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -235,12 +235,18 @@ end
 if is_available "telescope.nvim" then
   maps.n["<leader>f"] = sections.f
   maps.n["<leader>g"] = sections.g
-  maps.n["<leader>gb"] = { function() require("telescope.builtin").git_branches() end, desc = "Git branches" }
-  maps.n["<leader>gc"] =
-    { function() require("telescope.builtin").git_commits() end, desc = "Git commits (repository)" }
-  maps.n["<leader>gC"] =
-    { function() require("telescope.builtin").git_bcommits() end, desc = "Git commits (current file)" }
-  maps.n["<leader>gt"] = { function() require("telescope.builtin").git_status() end, desc = "Git status" }
+  maps.n["<leader>gb"] =
+    { function() require("telescope.builtin").git_branches { use_file_path = true } end, desc = "Git branches" }
+  maps.n["<leader>gc"] = {
+    function() require("telescope.builtin").git_commits { use_file_path = true } end,
+    desc = "Git commits (repository)",
+  }
+  maps.n["<leader>gC"] = {
+    function() require("telescope.builtin").git_bcommits { use_file_path = true } end,
+    desc = "Git commits (current file)",
+  }
+  maps.n["<leader>gt"] =
+    { function() require("telescope.builtin").git_status { use_file_path = true } end, desc = "Git status" }
   maps.n["<leader>f<CR>"] = { function() require("telescope.builtin").resume() end, desc = "Resume previous search" }
   maps.n["<leader>f'"] = { function() require("telescope.builtin").marks() end, desc = "Find marks" }
   maps.n["<leader>f/"] =


### PR DESCRIPTION
This makes it so that the git root used for telescope commands is determined based on the file you are in when calling it. This prevents instances where the wrong git commits/branches are brought up. For example, if you have a project open, but you decide to open up a single file from another git repo (say your `.zshrc`), `require("telescope.builtin").git_commits()` will bring up the commit history for the original project, while `require("telescope.builtin").git_bcommits()` won't even work.