### PR TITLE
chore(alpha): remove unecessary alpha startup autocmd

### DIFF
--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -183,24 +183,6 @@ if is_available "alpha-nvim" then
       end
     end,
   })
-  autocmd("VimEnter", {
-    desc = "Start Alpha when vim is opened with no arguments",
-    group = augroup("alpha_autostart", { clear = true }),
-    callback = function()
-      local should_skip = false
-      if vim.fn.argc() > 0 or vim.fn.line2byte(vim.fn.line "$") ~= -1 or not vim.o.modifiable then
-        should_skip = true
-      else
-        for _, arg in pairs(vim.v.argv) do
-          if arg == "-b" or arg == "-c" or vim.startswith(arg, "+") or arg == "-S" then
-            should_skip = true
-            break
-          end
-        end
-      end
-      if not should_skip then require("alpha").start(true, require("alpha").default_config) end
-    end,
-  })
 end
 
 if is_available "resession.nvim" then

--- a/lua/plugins/alpha.lua
+++ b/lua/plugins/alpha.lua
@@ -1,5 +1,6 @@
 return {
   "goolord/alpha-nvim",
+  event = "VimEnter",
   cmd = "Alpha",
   opts = function()
     local dashboard = require "alpha.themes.dashboard"

--- a/lua/plugins/alpha.lua
+++ b/lua/plugins/alpha.lua
@@ -31,7 +31,6 @@ return {
 
     dashboard.config.layout[1].val = vim.fn.max { 2, vim.fn.floor(vim.fn.winheight(0) * 0.2) }
     dashboard.config.layout[3].val = 5
-    dashboard.config.opts.noautocmd = true
     return dashboard
   end,
   config = require "plugins.configs.alpha",


### PR DESCRIPTION
This fixes an issue where the FileType autocmd is not emitted by Alpha, resulting in plugins like `mini.indentscope` being enabled on the alpha.