### PR TITLE
fix: closing last buffer in a tabpage closes the tab

### DIFF
--- a/lua/astronvim/utils/buffer.lua
+++ b/lua/astronvim/utils/buffer.lua
@@ -148,6 +148,10 @@ function M.close(bufnr, force)
         return
       end
     end
+    if #vim.t.bufs < 2 then
+      bufnr = vim.api.nvim_get_current_buf()
+      vim.cmd.tabclose()
+    end
     require("mini.bufremove").delete(bufnr, force)
   else
     vim.cmd((force and "bd!" or "confirm bd") .. (bufnr == nil and "" or bufnr))


### PR DESCRIPTION
Previously, closing a the last buffer resulted in the next loaded buffer in the jumplist being displayed in the current tabpage window. The fix checks if there are less than 2 buffers in the tab. If yes, save the current buffer_number, close the tab, and proceed to close the buffer(which remains hidden at this point). The next tab's window is selected, depending on the jumplist.