### PR TITLE
fix(options): don't set `smartindent`

### DIFF
--- a/lua/astronvim/options.lua
+++ b/lua/astronvim/options.lua
@@ -36,7 +36,6 @@ local options = astronvim.user_opts("options", {
     sidescrolloff = 8, -- Number of columns to keep at the sides of the cursor
     signcolumn = "yes", -- Always show the sign column
     smartcase = true, -- Case sensitivie searching
-    smartindent = true, -- Smarter autoindentation
     splitbelow = true, -- Splitting a new window below the current one
     splitright = true, -- Splitting a new window at the right of the current one
     tabstop = 2, -- Number of space in a tab


### PR DESCRIPTION
Any lines starting with a `#` is unable to be indented with `smartindent`

Related issues:

- https://github.com/LunarVim/LunarVim/issues/3219
- https://github.com/LnL7/vim-nix/issues/16

I confirmed this problem also exist in AstroNvim.

## AstroNvim

- AstroNvim Version: v3.33.2
- Neovim Version: v0.9.1
- OK Using stable Neovim >= 0.8.0
- OK `git` is installed: Used for core functionality such as updater and plugin management
- OK `xdg-open` is installed: Used for `gx` mapping for opening files with system opener (Optional)
- WARNING `lazygit` is not installed: Used for mappings to pull up git TUI (Optional)
- OK `node` is installed: Used for mappings to pull up node REPL (Optional)
- OK `gdu` is installed: Used for mappings to pull up disk usage analyzer (Optional)
- WARNING `btm` is not installed: Used for mappings to pull up system monitor (Optional)
- OK `python` is installed: Used for mappings to pull up python REPL (Optional)

## Operating System

NixOS 23.05 & macOS 13.4.1

## Terminal

kitty & alacritty

## Screenshots

[astronvim-indentation-issue.webm](https://github.com/AstroNvim/AstroNvim/assets/22363274/ef18f590-f768-4b2f-907c-f6b62cdb58cc)
