### PR TITLE
feat(mappings): add visual selection git commits telescope mapping

### DIFF
--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -246,7 +246,7 @@ if is_available "telescope.nvim" then
     desc = "Git commits (current file)",
   }
   maps.x["<leader>gc"] = {
-    '<cmd>lua require("telescope.builtin").git_bcommits_range { use_file_path = true }<cr><esc>',
+    function() require("telescope.builtin").git_bcommits_range { use_file_path = true } end,
     desc = "Git commits (selected range)",
   }
   maps.n["<leader>gt"] =

--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -245,6 +245,10 @@ if is_available "telescope.nvim" then
     function() require("telescope.builtin").git_bcommits { use_file_path = true } end,
     desc = "Git commits (current file)",
   }
+  maps.x["<leader>gc"] = {
+    function() require("telescope.builtin").git_bcommits_range { use_file_path = true } end,
+    desc = "Git commits (selected range)",
+  }
   maps.n["<leader>gt"] =
     { function() require("telescope.builtin").git_status { use_file_path = true } end, desc = "Git status" }
   maps.n["<leader>f<CR>"] = { function() require("telescope.builtin").resume() end, desc = "Resume previous search" }

--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -246,7 +246,7 @@ if is_available "telescope.nvim" then
     desc = "Git commits (current file)",
   }
   maps.x["<leader>gc"] = {
-    function() require("telescope.builtin").git_bcommits_range { use_file_path = true } end,
+    '<cmd>lua require("telescope.builtin").git_bcommits_range { use_file_path = true }<cr><esc>',
     desc = "Git commits (selected range)",
   }
   maps.n["<leader>gt"] =


### PR DESCRIPTION
It seems like opening the picker doesn't exit visual mode automatically, so this hack is needed. Also, should the other selection mode (`v`) mappings be changed to visual mode (`x`) mappings?

Edit: the hack is no longer needed as of https://github.com/nvim-telescope/telescope.nvim/commit/1228f3b15ca3d9b95dcb92efda6a3448871030bd