### PR TITLE
fix(status): always show correct filename for files without a name

### DIFF
--- a/lua/astronvim/utils/status/provider.lua
+++ b/lua/astronvim/utils/status/provider.lua
@@ -293,8 +293,9 @@ function M.filename(opts)
     modify = ":t",
   }, opts)
   return function(self)
-    local filename = vim.fn.fnamemodify(opts.fname(self and self.bufnr or 0), opts.modify)
-    return status_utils.stylize((filename == "" and opts.fallback or filename), opts)
+    local path = opts.fname(self and self.bufnr or 0)
+    local filename = vim.fn.fnamemodify(path, opts.modify)
+    return status_utils.stylize((path == "" and opts.fallback or filename), opts)
   end
 end
 

--- a/lua/astronvim/utils/status/provider.lua
+++ b/lua/astronvim/utils/status/provider.lua
@@ -288,7 +288,7 @@ end
 -- @see astronvim.utils.status.utils.stylize
 function M.filename(opts)
   opts = extend_tbl({
-    fallback = "[No Name]",
+    fallback = "Empty",
     fname = function(nr) return vim.api.nvim_buf_get_name(nr) end,
     modify = ":t",
   }, opts)

--- a/lua/astronvim/utils/status/provider.lua
+++ b/lua/astronvim/utils/status/provider.lua
@@ -288,7 +288,7 @@ end
 -- @see astronvim.utils.status.utils.stylize
 function M.filename(opts)
   opts = extend_tbl({
-    fallback = "Empty",
+    fallback = "[No Name]",
     fname = function(nr) return vim.api.nvim_buf_get_name(nr) end,
     modify = ":t",
   }, opts)


### PR DESCRIPTION
This PR does two things: 

1. It changes the default fallback to display noname buffers in heirline as "[No Name]"  instead of "Empty" (which imo doesn't really make sense once the buffer has been modified) to align with default vim naming.
2. It also fixes an issue where when a modifier (other than ":t") is applied to the `file_info` component, the fallback is not always shown, for example with the following custom component:
```lua
status.component.file_info {
  filename = { modify = ":~:." },
},
```

The issue is that applying custom modifiers to `filename` for a `[No Name]` file sets it from an empty string to a nonempty string. This PR resolves this by performing the fallback check on the original path before it was modified.


Here's a screenshot showing the changes:

<img width="1780" alt="image" src="https://github.com/AstroNvim/AstroNvim/assets/56745535/819d9655-07d1-44ce-9094-3dbc94eeac99">