### PR TITLE
fix(ui): improve toggle syntax highlighting

### DIFF
--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -446,7 +446,7 @@ maps.n["<leader>uS"] = { ui.toggle_conceal, desc = "Toggle conceal" }
 maps.n["<leader>ut"] = { ui.toggle_tabline, desc = "Toggle tabline" }
 maps.n["<leader>uu"] = { ui.toggle_url_match, desc = "Toggle URL highlight" }
 maps.n["<leader>uw"] = { ui.toggle_wrap, desc = "Toggle wrap" }
-maps.n["<leader>uy"] = { ui.toggle_syntax, desc = "Toggle syntax highlight" }
+maps.n["<leader>uy"] = { ui.toggle_syntax, desc = "Toggle syntax highlighting (buffer)" }
 maps.n["<leader>uh"] = { ui.toggle_foldcolumn, desc = "Toggle foldcolumn" }
 
 utils.set_mappings(astronvim.user_opts("mappings", maps))

--- a/lua/astronvim/utils/ui.lua
+++ b/lua/astronvim/utils/ui.lua
@@ -203,9 +203,10 @@ function M.toggle_wrap()
 end
 
 --- Toggle syntax highlighting and treesitter
-function M.toggle_syntax()
+---@param bufnr? number the buffer to toggle syntax on
+function M.toggle_buffer_syntax(bufnr)
   local ts_avail, parsers = pcall(require, "nvim-treesitter.parsers")
-  local buf = vim.api.nvim_win_get_buf(0)
+  local buf = bufnr or vim.api.nvim_win_get_buf(0)
   if vim.bo[buf].syntax == "off" then
     if ts_avail and parsers.has_parser() then vim.cmd.TSBufEnable "highlight" end
     vim.cmd.setlocal "syntax=on"

--- a/lua/astronvim/utils/ui.lua
+++ b/lua/astronvim/utils/ui.lua
@@ -204,7 +204,7 @@ end
 
 --- Toggle syntax highlighting and treesitter
 ---@param bufnr? number the buffer to toggle syntax on
-function M.toggle_buffer_syntax(bufnr)
+function M.toggle_syntax(bufnr)
   local ts_avail, parsers = pcall(require, "nvim-treesitter.parsers")
   local buf = bufnr or vim.api.nvim_win_get_buf(0)
   if vim.bo[buf].syntax == "off" then

--- a/lua/astronvim/utils/ui.lua
+++ b/lua/astronvim/utils/ui.lua
@@ -202,14 +202,15 @@ end
 --- Toggle syntax highlighting and treesitter
 function M.toggle_syntax()
   local ts_avail, parsers = pcall(require, "nvim-treesitter.parsers")
-  if vim.g.syntax_on then -- global var for on//off
-    if ts_avail and parsers.has_parser() then vim.cmd.TSBufDisable "highlight" end
-    vim.cmd.syntax "off" -- set vim.g.syntax_on = false
-  else
+  local buf = vim.api.nvim_win_get_buf(0)
+  if vim.bo[buf].syntax == "off" then
     if ts_avail and parsers.has_parser() then vim.cmd.TSBufEnable "highlight" end
-    vim.cmd.syntax "on" -- set vim.g.syntax_on = true
+    vim.cmd.setlocal "syntax=on"
+  else
+    if ts_avail and parsers.has_parser() then vim.cmd.TSBufDisable "highlight" end
+    vim.cmd.setlocal "syntax=off"
   end
-  notify(string.format("syntax %s", bool2str(vim.g.syntax_on)))
+  notify(string.format("syntax %s", bool2str(vim.bo[buf].syntax ~= "off")))
 end
 
 --- Toggle URL/URI syntax highlighting rules

--- a/lua/astronvim/utils/ui.lua
+++ b/lua/astronvim/utils/ui.lua
@@ -206,17 +206,17 @@ end
 ---@param bufnr? number the buffer to toggle syntax on
 function M.toggle_syntax(bufnr)
   local ts_avail, parsers = pcall(require, "nvim-treesitter.parsers")
-  local buf = bufnr or vim.api.nvim_win_get_buf(0)
-  if vim.bo[buf].syntax == "off" then
-    if ts_avail and parsers.has_parser() then vim.cmd.TSBufEnable "highlight" end
-    vim.cmd.setlocal "syntax=on"
-    if not vim.b.semantic_tokens_enabled then M.toggle_buffer_semantic_tokens(buf, true) end
+  bufnr = bufnr or vim.api.nvim_win_get_buf(0)
+  if vim.bo[bufnr].syntax == "off" then
+    if ts_avail and parsers.has_parser() then vim.treesitter.start(bufnr) end
+    vim.bo[bufnr].syntax = "on"
+    if not vim.b.semantic_tokens_enabled then M.toggle_buffer_semantic_tokens(bufnr, true) end
   else
-    if ts_avail and parsers.has_parser() then vim.cmd.TSBufDisable "highlight" end
-    vim.cmd.setlocal "syntax=off"
-    if vim.b.semantic_tokens_enabled then M.toggle_buffer_semantic_tokens(buf, true) end
+    if ts_avail and parsers.has_parser() then vim.treesitter.stop(bufnr) end
+    vim.bo[bufnr].syntax = "off"
+    if vim.b.semantic_tokens_enabled then M.toggle_buffer_semantic_tokens(bufnr, true) end
   end
-  notify(string.format("syntax %s", bool2str(vim.bo[buf].syntax ~= "off")))
+  notify(string.format("syntax %s", vim.bo[bufnr].syntax))
 end
 
 --- Toggle URL/URI syntax highlighting rules


### PR DESCRIPTION
Currently, `toggle_syntax_highlighting` is rather janky. It completely breaks when `vim.g.ui_notifications_enabled=true` (prolly something to do with syntax highlighting within the notify buffer) and doesn't always work as expected between multiple buffers.

This PR does 3 things:
1. It fixes syntax highlighting when ui notifications are enabled
2. It fixes the inconsistent toggling behavior between buffers by enabling and disabling syntax locally instead of globally (TS highlighting was already buffer-local before, this just makes native syntax highlighting buffer-local as well)
3. It also disables/enables semantic token highlighting when appropriate