### PR TITLE
fix(ui): don't check every lsp client when toggling semantic tokens

### DIFF
--- a/lua/astronvim/utils/ui.lua
+++ b/lua/astronvim/utils/ui.lua
@@ -93,7 +93,7 @@ end
 function M.toggle_buffer_semantic_tokens(bufnr, silent)
   bufnr = bufnr or 0
   vim.b[bufnr].semantic_tokens_enabled = not vim.b[bufnr].semantic_tokens_enabled
-  for _, client in ipairs(vim.lsp.get_active_clients()) do
+  for _, client in ipairs(vim.lsp.get_active_clients { bufnr = bufnr }) do
     if client.server_capabilities.semanticTokensProvider then
       vim.lsp.semantic_tokens[vim.b[bufnr].semantic_tokens_enabled and "start" or "stop"](bufnr, client.id)
       ui_notify(


### PR DESCRIPTION
This *actually* fixes the duplicate messages when toggling semantic token highlighting.

![Screen Recording 2023-07-23 at 8 32 38 AM](https://github.com/AstroNvim/AstroNvim/assets/56745535/8fa4ce47-7b01-4c22-ab27-c4851bd79e21)
