### PR TITLE
fix(autocmds): improve `AstroColorScheme` autocmds

### DIFF
--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -250,7 +250,7 @@ end
 autocmd({ "VimEnter", "ColorScheme" }, {
   desc = "Load custom highlights from user configuration",
   group = augroup("astronvim_highlights", { clear = true }),
-  callback = function()
+  callback = function(args)
     if vim.g.colors_name then
       for _, module in ipairs { "init", vim.g.colors_name } do
         for group, spec in pairs(astronvim.user_opts("highlights." .. module)) do
@@ -258,7 +258,7 @@ autocmd({ "VimEnter", "ColorScheme" }, {
         end
       end
     end
-    astroevent "ColorScheme"
+    if args.event == "ColorScheme" then astroevent "ColorScheme" end
   end,
 })
 

--- a/lua/plugins/configs/heirline.lua
+++ b/lua/plugins/configs/heirline.lua
@@ -108,8 +108,7 @@ return function(_, opts)
   heirline.setup(opts)
 
   local augroup = vim.api.nvim_create_augroup("Heirline", { clear = true })
-  vim.api.nvim_create_autocmd("User", {
-    pattern = "AstroColorScheme",
+  vim.api.nvim_create_autocmd("ColorScheme", {
     group = augroup,
     desc = "Refresh heirline colors",
     callback = function() require("heirline.utils").on_colorscheme(setup_colors()) end,


### PR DESCRIPTION
Summary: 

1. Don't emit AstroColorScheme twice on startup
2. Fixes a weird issue where heirline hl groups are incorectly set (it happens each time lazy auto installs a plugin on startup and other times rather inconsistently). I honestly thought 1) would do the trick, but apparently not 🤷, lmk if there's a better way of going about things

<img width="1097" alt="image" src="https://github.com/AstroNvim/AstroNvim/assets/56745535/7317b075-c8de-4ec9-9ea1-90ba98f07341">


