### PR TITLE
fix(autocmds): resolve git dir for symlinked files in `AstroGitFile` event

### DIFF
--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -266,11 +266,12 @@ autocmd({ "BufReadPost", "BufNewFile", "BufWritePost" }, {
   desc = "AstroNvim user events for file detection (AstroFile and AstroGitFile)",
   group = augroup("file_user_events", { clear = true }),
   callback = function(args)
-    if not (vim.fn.expand "%" == "" or vim.api.nvim_get_option_value("buftype", { buf = args.buf }) == "nofile") then
+    local current_file = vim.fn.resolve(vim.fn.expand "%")
+    if not (current_file == "" or vim.api.nvim_get_option_value("buftype", { buf = args.buf }) == "nofile") then
       astroevent "File"
       if
         require("astronvim.utils.git").file_worktree()
-        or utils.cmd({ "git", "-C", vim.fn.expand "%:p:h", "rev-parse" }, false)
+        or utils.cmd({ "git", "-C", vim.fn.fnamemodify(current_file, ":p:h"), "rev-parse" }, false)
       then
         astroevent "GitFile"
         vim.api.nvim_del_augroup_by_name "file_user_events"

--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -267,6 +267,7 @@ if is_available "telescope.nvim" then
           prompt_title = "Config Files",
           search_dirs = search_dirs,
           cwd = cwd,
+          follow = true,
         } -- call telescope
       end
     end,


### PR DESCRIPTION
I was thinking about switching over to stow to manage my dotfiles when I encountered this issue where gitsigns wasn't loaded when opening the files from the symlink. It turns out that symlinks were not being resolved in the git directory check. This fixes that.

Edit: I also enabled the follow option in the telescope finder to fix this for the "Find AstroNvim config files" mapping.