### PR TITLE
feat(neo-tree): add mappings to navigate neo-tree filter popup

### DIFF
--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -126,6 +126,10 @@ return {
           l = "child_or_open",
           o = "open",
         },
+        fuzzy_finder_mappings = { -- define keymaps for filter popup window in fuzzy_finder_mode
+          ["<C-j>"] = "move_cursor_down",
+          ["<C-k>"] = "move_cursor_up",
+        },
       },
       filesystem = {
         follow_current_file = { enabled = true },


### PR DESCRIPTION
Sets `<c-j>`/`<c-/k>` to navigate up/down neo-tree filter results to align with telescope and cmp bindings