### PR TITLE
fix(autocmds): set cmdheight=0 in alpha

### DIFF
--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -161,7 +161,7 @@ autocmd("BufEnter", {
 
 if is_available "alpha-nvim" then
   autocmd({ "User", "BufEnter" }, {
-    desc = "Disable status and tablines for alpha",
+    desc = "Disable status, tablines, and cmdheight for alpha",
     group = augroup("alpha_settings", { clear = true }),
     callback = function(args)
       if
@@ -170,14 +170,19 @@ if is_available "alpha-nvim" then
           or (args.event == "BufEnter" and vim.api.nvim_get_option_value("filetype", { buf = args.buf }) == "alpha")
         ) and not vim.g.before_alpha
       then
-        vim.g.before_alpha = { showtabline = vim.opt.showtabline:get(), laststatus = vim.opt.laststatus:get() }
-        vim.opt.showtabline, vim.opt.laststatus = 0, 0
+        vim.g.before_alpha = {
+          showtabline = vim.opt.showtabline:get(),
+          laststatus = vim.opt.laststatus:get(),
+          cmdheight = vim.opt.cmdheight:get(),
+        }
+        vim.opt.showtabline, vim.opt.laststatus, vim.opt.cmdheight = 0, 0, 0
       elseif
         vim.g.before_alpha
         and args.event == "BufEnter"
         and vim.api.nvim_get_option_value("buftype", { buf = args.buf }) ~= "nofile"
       then
-        vim.opt.laststatus, vim.opt.showtabline = vim.g.before_alpha.laststatus, vim.g.before_alpha.showtabline
+        vim.opt.laststatus, vim.opt.showtabline, vim.opt.cmdheight =
+          vim.g.before_alpha.laststatus, vim.g.before_alpha.showtabline, vim.g.before_alpha.cmdheight
         vim.g.before_alpha = nil
       end
     end,


### PR DESCRIPTION
We probably shouldn't show this
<img width="685" alt="image" src="https://github.com/AstroNvim/AstroNvim/assets/56745535/03009ce2-6069-4824-9a0a-54ff67216423">
