### PR TITLE
feat(lsp): symbol search for word under cursor

### DIFF
--- a/lua/astronvim/utils/lsp.lua
+++ b/lua/astronvim/utils/lsp.lua
@@ -352,9 +352,12 @@ M.on_attach = function(client, bufnr)
     if lsp_mappings.n["<leader>lG"] then
       lsp_mappings.n["<leader>lG"][1] = function()
         vim.ui.input(
-          { prompt = "Symbol Query: " },
+          { prompt = "Symbol Query: (leave empty for word under cursor)" },
           function(query)
             if query then
+              if query == "" then
+                query = vim.fn.expand("<cword>")  -- word under cursor if given query is empty
+              end
               require("telescope.builtin").lsp_workspace_symbols {
                 query = query,
                 prompt_title = string.format("Find word (%s)", query),

--- a/lua/astronvim/utils/lsp.lua
+++ b/lua/astronvim/utils/lsp.lua
@@ -351,8 +351,15 @@ M.on_attach = function(client, bufnr)
     end
     if lsp_mappings.n["<leader>lG"] then
       lsp_mappings.n["<leader>lG"][1] = function()
-        vim.ui.input({ prompt = "Symbol Query: " }, function(query)
-          if query then require("telescope.builtin").lsp_workspace_symbols { query = query } end
+        vim.ui.input(
+          { prompt = "Symbol Query: " },
+          function(query)
+            if query then
+              require("telescope.builtin").lsp_workspace_symbols {
+                query = query,
+                prompt_title = string.format("Find word (%s)", query),
+              }
+            end
         end)
       end
     end


### PR DESCRIPTION
I wanted the possibility to do a workspace symbol search without having to type the word as it is right now, but getting it from a word of the current buffer: Many well-known IDEs consider the word under the cursor or the selected text after pressing the "symbol search" shortcut.

I had multiple ways to achieve this:
- define the `default` parameter in the `vim.ui.input()` function, which would pre-fill the dialog with the word under the cursor. However, the main drawback is that if the user wants to do an unrelated workspace symbol search (unrelated to the word under the cursor), they would have to delete (by pressing backspace) the whole word before typing.
- Define a workspace symbol search in visual mode. This way, the user would have to select the word (or more than a word) beforehand. I disregarded this possibility because getting the selected text in Lua is not [that "easy"](https://github.com/neovim/neovim/pull/13896): for now, if I understood correctly, a lot of project uses internal implemented methods which uses `getpos` for the  `'<`  and the `'>` chars, slice the result, etcetc.
- If the given query argument is empty, consider the word under the cursor.

Hence, I opted for the last option: this PR adds the possibility to quickly do a workspace search symbol for the word under the cursor.

Additionally, another commit puts the queried word in the telescope's window result as a title.

This is my first time coding in Lua and contributing to this project, do not hesitate to correct me if I did something wrong, I'm all ears.

Let me know what do you think.