### PR TITLE
revert(luasnip): don't map `store_selection_keys` by default

### DIFF
--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -9,7 +9,6 @@ return {
       history = true,
       delete_check_events = "TextChanged",
       region_check_events = "CursorMoved",
-      store_selection_keys = "<C-x>",
     },
     config = require "plugins.configs.luasnip",
   },


### PR DESCRIPTION
Refs: 67c2c71

Closes #2225

Bugs Fixed:
- removed `<C-x>` mapping from luasnip, which is for decrementing numbers by default
