### PR TITLE
fix(neo-tree)!: conflict with new "Order by" keymaps

### DIFF
--- a/lua/astronvim/plugins/neo-tree.lua
+++ b/lua/astronvim/plugins/neo-tree.lua
@@ -171,7 +171,6 @@ return {
           Y = "copy_selector",
           h = "parent_or_close",
           l = "child_or_open",
-          o = "open",
         },
         fuzzy_finder_mappings = { -- define keymaps for filter popup window in fuzzy_finder_mode
           ["<C-j>"] = "move_cursor_down",


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Removes the "o" keymap as there is a conflict with Neotree's new default ["Order by" keymaps]
(https://github.com/nvim-neo-tree/neo-tree.nvim/commit/70ab62c8cc5d039766c039597c7c33a76d74fd11). Hopefully shouldn't be too much of a breaking change since there are several other existing keymaps that do the same thing.

## ℹ Additional Information
![image](https://github.com/AstroNvim/AstroNvim/assets/56745535/44c2810d-823e-4139-bc32-017edd73787c)