### PR TITLE
fix(autocmds): refresh Neo-Tree filesystem when closing lazygit

### DIFF
--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -250,6 +250,14 @@ if is_available "neo-tree.nvim" then
       if package.loaded["neo-tree.sources.git_status"] then require("neo-tree.sources.git_status").refresh() end
     end,
   })
+  autocmd("TermClose", {
+    pattern = "*lazygit*",
+    desc = "Refresh Neo-Tree filesystem when closing lazygit",
+    group = augroup("neotree_fs_refresh", { clear = true }),
+    callback = function()
+      if package.loaded["neo-tree.sources.manager"] then require("neo-tree.sources.manager").refresh("filesystem") end
+    end,
+  })
 end
 
 autocmd("ColorScheme", {

--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -243,18 +243,11 @@ if is_available "neo-tree.nvim" then
     end,
   })
   autocmd("TermClose", {
-    pattern = "*lazygit",
-    desc = "Refresh Neo-Tree git when closing lazygit",
-    group = augroup("neotree_git_refresh", { clear = true }),
+    pattern = "*lazygit*",
+    desc = "Refresh Neo-Tree when closing lazygit",
+    group = augroup("neotree_refresh", { clear = true }),
     callback = function()
       if package.loaded["neo-tree.sources.git_status"] then require("neo-tree.sources.git_status").refresh() end
-    end,
-  })
-  autocmd("TermClose", {
-    pattern = "*lazygit*",
-    desc = "Refresh Neo-Tree filesystem when closing lazygit",
-    group = augroup("neotree_fs_refresh", { clear = true }),
-    callback = function()
       if package.loaded["neo-tree.sources.manager"] then require("neo-tree.sources.manager").refresh("filesystem") end
     end,
   })

--- a/lua/astronvim/autocmds.lua
+++ b/lua/astronvim/autocmds.lua
@@ -247,8 +247,13 @@ if is_available "neo-tree.nvim" then
     desc = "Refresh Neo-Tree when closing lazygit",
     group = augroup("neotree_refresh", { clear = true }),
     callback = function()
-      if package.loaded["neo-tree.sources.git_status"] then require("neo-tree.sources.git_status").refresh() end
-      if package.loaded["neo-tree.sources.manager"] then require("neo-tree.sources.manager").refresh("filesystem") end
+      local manager_avail, manager = pcall(require, "neo-tree.sources.manager")
+      if manager_avail then
+        for _, source in ipairs { "filesystem", "git_status", "document_symbols" } do
+          local module = "neo-tree.sources." .. source
+          if package.loaded[module] then manager.refresh(require(module).name) end
+        end
+      end
     end,
   })
 end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This makes the `neo-tree` filesystem refresh when closing a lazygit terminal. AstroNvim is already doing this for the git status source, and it would be good to refresh the other sources as well. The buffer source, obviously, wouldn't need to be refreshed.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
