### PR TITLE
chore(heirline): add tabline padding to undotree

### DIFF
--- a/lua/plugins/heirline.lua
+++ b/lua/plugins/heirline.lua
@@ -50,7 +50,7 @@ return {
           condition = function(self)
             self.winid = vim.api.nvim_tabpage_list_wins(0)[1]
             return status.condition.buffer_matches(
-              { filetype = { "aerial", "dapui_.", "dap-repl", "neo%-tree", "NvimTree", "edgy" } },
+              { filetype = { "aerial", "dapui_.", "dap-repl", "neo%-tree", "NvimTree", "edgy", "undotree" } },
               vim.api.nvim_win_get_buf(self.winid)
             )
           end,


### PR DESCRIPTION
## 📑 Description

Adds tabline padding for undotree.

At first I thought it would be best to leave this in a personal config since undo tree is not included in AstroNvim, but unfortunately doing so is not that simple and results in the mental overhead of having to manually keep a user heirline config in sync with the core one. I thought it might be best to include it in core given the plugin's popularity (especially considering edgy and Nvim-tree are there as well).

## ℹ Additional Information
**Before**
<img width="1786" alt="image" src="https://github.com/AstroNvim/AstroNvim/assets/56745535/4703b1b2-37ba-4cb3-af68-2caac7ec65f8">
**After**
<img width="1792" alt="image" src="https://github.com/AstroNvim/AstroNvim/assets/56745535/a615b5c7-5e57-40c8-9705-30a4a3949201">


