### PR TITLE
chore(astro): show "W" before search count in cmdline when wrapping

### DIFF
--- a/lua/astronvim/options.lua
+++ b/lua/astronvim/options.lua
@@ -1,5 +1,5 @@
 vim.opt.viewoptions:remove "curdir" -- disable saving current directory with views
-vim.opt.shortmess:append { s = true, I = true } -- disable startup message
+vim.opt.shortmess:append { I = true } -- disable startup message
 vim.opt.backspace:append { "nostop" } -- don't stop backspace at insert
 if vim.fn.has "nvim-0.9" == 1 then
   vim.opt.diffopt:append "linematch:60" -- enable linematch diff algorithm


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
Shows the "W" character before the search count when wrapping around the document. Only applies when cmdheight=1.
## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

<img width="97" alt="image" src="https://github.com/AstroNvim/AstroNvim/assets/56745535/e2c82ff9-d563-48d7-bdaf-41418de7dedb">

