### PR TITLE
fix(nvim-ts-autotag): TS closing tag disabled until issue is closed

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -3,7 +3,7 @@ return {
   dependencies = {
     "JoosepAlviste/nvim-ts-context-commentstring",
     "nvim-treesitter/nvim-treesitter-textobjects",
-    -- FIXME: remove when https://github.com/windwp/nvim-ts-autotag/issues/125 closed.
+    -- HACK: remove when https://github.com/windwp/nvim-ts-autotag/issues/125 closed.
     {
       "windwp/nvim-ts-autotag",
       opts = {

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -3,7 +3,16 @@ return {
   dependencies = {
     "JoosepAlviste/nvim-ts-context-commentstring",
     "nvim-treesitter/nvim-treesitter-textobjects",
-    "windwp/nvim-ts-autotag",
+    -- FIXME: remove when https://github.com/windwp/nvim-ts-autotag/issues/125 closed.
+    {
+      "windwp/nvim-ts-autotag",
+      opts = {
+        autotag = {
+          enable = true,
+          enable_close_on_slash = false,
+        },
+      },
+    },
   },
   event = "User AstroFile",
   cmd = {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

bug: Autocompletion with slash bug with tsx. Typing something like `<div/`, will result in `<div/div>`, which is invalid JSX. This disables that functionality until it is fixed.

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

https://github.com/windwp/nvim-ts-autotag/issues/125
