### PR TITLE
feat(ui)!: use `mini.indentscope` for highlighting current context

### DIFF
--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -437,6 +437,9 @@ if is_available "nvim-cmp" then maps.n["<leader>uc"] = { ui.toggle_cmp, desc = "
 if is_available "nvim-colorizer.lua" then
   maps.n["<leader>uC"] = { "<cmd>ColorizerToggle<cr>", desc = "Toggle color highlight" }
 end
+if is_available "mini.indentscope" then
+  maps.n["<leader>uI"] = { ui.toggle_buffer_indent_guides, desc = "Toggle indent guides (buffer)" }
+end
 maps.n["<leader>ud"] = { ui.toggle_diagnostics, desc = "Toggle diagnostics" }
 maps.n["<leader>ug"] = { ui.toggle_signcolumn, desc = "Toggle signcolumn" }
 maps.n["<leader>ui"] = { ui.set_indent, desc = "Change indent setting" }

--- a/lua/astronvim/utils/ui.lua
+++ b/lua/astronvim/utils/ui.lua
@@ -172,6 +172,20 @@ function M.toggle_signcolumn(silent)
   ui_notify(silent, string.format("signcolumn=%s", vim.wo.signcolumn))
 end
 
+--- Toggle indent guides
+---@param silent? boolean if true then don't sent a notification
+function M.toggle_buffer_indent_guides(silent)
+  vim.g.indent_blankline_enabled = not vim.g.indent_blankline_enabled
+  pcall(vim.cmd.IndentBlanklineRefresh)
+  vim.g.miniindentscope_disable = not vim.g.miniindentscope_disable
+  if MiniIndentscope and not vim.g.miniindentscope_disable then
+    MiniIndentscope.draw()
+  else
+    MiniIndentscope.undraw()
+  end
+  ui_notify(silent, "Indent guides " .. (bool2str(vim.g.indent_blankline_enabled)))
+end
+
 --- Set the indent and tab related numbers
 ---@param silent? boolean if true then don't sent a notification
 function M.set_indent(silent)

--- a/lua/plugins/ui.lua
+++ b/lua/plugins/ui.lua
@@ -78,52 +78,106 @@ return {
     opts = { user_default_options = { names = false } },
   },
   {
-    "lukas-reineke/indent-blankline.nvim",
+    "echasnovski/mini.indentscope",
     event = "User AstroFile",
-    opts = {
-      buftype_exclude = {
-        "nofile",
-        "terminal",
+    dependencies = {
+      {
+        "lukas-reineke/indent-blankline.nvim",
+        init = function()
+          vim.g.indent_blankline_buftype_exclude = {
+            "nofile",
+            "prompt",
+            "quickfix",
+            "terminal",
+          }
+          vim.g.indent_blankline_filetype_exclude = {
+            "NvimTree",
+            "Trouble",
+            "aerial",
+            "alpha",
+            "checkhealth",
+            "dashboard",
+            "help",
+            "help",
+            "lazy",
+            "lspinfo",
+            "man",
+            "neo-tree",
+            "neogitstatus",
+            "startify",
+          }
+          vim.g.indent_blankline_bufname_exclude = {}
+        end,
+        opts = {
+          context_patterns = {
+            "class",
+            "return",
+            "function",
+            "method",
+            "^if",
+            "^while",
+            "jsx_element",
+            "^for",
+            "^object",
+            "^table",
+            "block",
+            "arguments",
+            "if_statement",
+            "else_clause",
+            "jsx_element",
+            "jsx_self_closing_element",
+            "try_statement",
+            "catch_clause",
+            "import_statement",
+            "operation_type",
+          },
+          show_trailing_blankline_indent = false,
+          use_treesitter = true,
+          char = "▏",
+          context_char = "▏",
+        },
       },
-      filetype_exclude = {
-        "help",
-        "startify",
-        "aerial",
-        "alpha",
-        "dashboard",
-        "lazy",
-        "neogitstatus",
-        "NvimTree",
-        "neo-tree",
-        "Trouble",
-      },
-      context_patterns = {
-        "class",
-        "return",
-        "function",
-        "method",
-        "^if",
-        "^while",
-        "jsx_element",
-        "^for",
-        "^object",
-        "^table",
-        "block",
-        "arguments",
-        "if_statement",
-        "else_clause",
-        "jsx_element",
-        "jsx_self_closing_element",
-        "try_statement",
-        "catch_clause",
-        "import_statement",
-        "operation_type",
-      },
-      show_trailing_blankline_indent = false,
-      use_treesitter = true,
-      char = "▏",
-      context_char = "▏",
-      show_current_context = true,
     },
+    init = function()
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = "*",
+        callback = function()
+          if
+            vim.tbl_contains(vim.g.indent_blankline_filetype_exclude, vim.bo["filetype"])
+            or vim.tbl_contains(vim.g.indent_blankline_buftype_exclude, vim.bo["buftype"])
+            or vim.tbl_contains(vim.g.indent_blankline_bufname_exclude, vim.api.nvim_buf_get_name(0))
+          then
+            vim.b.miniindentscope_disable = true
+          end
+        end,
+      })
+    end,
+    opts = function()
+      local success, wk = pcall(require, "which-key")
+      if success then
+        local textobjects = {
+          ["ii"] = [[inside indent scope]],
+          ["ai"] = [[around indent scope]],
+        }
+        wk.register(textobjects, { mode = { "x", "o" } })
+      end
+
+      local indentscope = require "mini.indentscope"
+      vim.defer_fn(function() indentscope.draw() end, 0)
+      return {
+        draw = {
+          delay = 0,
+          animation = indentscope.gen_animation.none(),
+        },
+        mappings = {
+          object_scope = "ii",
+          object_scope_with_border = "ai",
+          goto_top = "[i",
+          goto_bottom = "]i",
+        },
+        symbol = "▏",
+        options = { try_as_border = true },
+      }
+    end,
   },
 }


### PR DESCRIPTION
## 📑 Description

**Problem**: The context highlighting built into `indent blankline` is rather buggy and not entirely accurate in many situations (see below screenshots below). 

**Solution**: `mini.indentscope` doesn't suffer the same drawbacks and is vastly more customizable. It might also be worth mentioning that LazyVim uses indent blankline for static indent guides and mini.indentscope for highlighting context.

It also comes with a number of enhancements:
1. Text objects for selecting everything inside and around an indentation guide (similar to https://github.com/arsham/indent-tools.nvim)
2. Navigating through indent scopes via `[i`/`]i` 
3. The option to indent at cursor location (useful for seeing incremental scopes with horizontal cursor movements)
![Screen Recording 2023-08-29 at 6 24 17 PM](https://github.com/AstroNvim/AstroNvim/assets/56745535/5ffb6fab-32bf-46e6-9986-cecbd169b958)
4. The ability to set the criteria for indent border (for instance, you can place cursor on function header to get scope of its body, which seems to be the default in other editors like vscode)
5. Cool looking animations, though I'm not that big of a fan and keep them disabled by default

Let me know if you think it should be included in AstroNvim by default (or left up to astrocommunity). This is still a WIP as I'm pretty sure the configuration will have to be done in Lazy's `config` function instead of `opts` and a new file will need to be created under "plugins/configs" to allow the user to extend AstroNvim's base config (though I'm not sure if this will change in v4).

## ℹ Additional Information

These are some examples of the inconsistent behavior in `indent blankline` that are fixed by `mini.indentscope`

**Large functions w/ many lines of code**
![Screen Recording 2023-08-29 at 6 10 23 PM](https://github.com/AstroNvim/AstroNvim/assets/56745535/2c794754-8952-4457-8204-ced63f742f0d)

**Incorrect context**
<img width="843" alt="image" src="https://github.com/AstroNvim/AstroNvim/assets/56745535/dc1f0aeb-11ed-4a1a-993b-bf8d3447d15b">
<img width="735" alt="image" src="https://github.com/AstroNvim/AstroNvim/assets/56745535/09f306ed-d118-48b3-a911-868715ad0c41">

**Ghosting/flickering when changing lines or undoing an edit**
![Screen Recording 2023-07-05 at 7 35 52 PM](https://github.com/lukas-reineke/indent-blankline.nvim/assets/56745535/2805c191-3ca1-4ec9-9f19-8f9758caab5c)

