### PR TITLE
fix(status provider): Check the buffer is valid to avoid crash

### DIFF
--- a/lua/astronvim/utils/status/provider.lua
+++ b/lua/astronvim/utils/status/provider.lua
@@ -330,7 +330,13 @@ end
 -- @see astronvim.utils.status.utils.stylize
 function M.unique_path(opts)
   opts = extend_tbl({
-    buf_name = function(bufnr) return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t") end,
+    buf_name = function(bufnr)
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t")
+      else
+        return ""
+      end
+    end,
     bufnr = 0,
     max_length = 16,
   }, opts)


### PR DESCRIPTION
Hey it's been a while. I hope you are doing well.

## What's the purpose of this PR?
It fixes a crash on heirline when using `git mergetool`.

## How does it work?
**Before patch**: Writing the diff causes heirline to crash.
![screenshot_2023-09-07_22-57-29_612382661](https://github.com/AstroNvim/AstroNvim/assets/3357792/fa1a23b4-91fc-4b04-ac6d-334d0151dd7e)

**After patch**: When writing the diff, it shows the result correctly. On this point we could press `:q` to complete the case of use. All good.
![screenshot_2023-09-07_22-57-56_187045117](https://github.com/AstroNvim/AstroNvim/assets/3357792/8d1a58c6-54a9-43f2-b0c5-27932bda2cd0)

## How to test

Set your diff tool to neovim with `git config --global mergetool.tool vimdiff `. Then run `git mergetool` on a repo with merge conflicts.