### PR TITLE
chore(heirline): add tabline padding to overseer

### DIFF
--- a/lua/plugins/heirline.lua
+++ b/lua/plugins/heirline.lua
@@ -49,10 +49,18 @@ return {
         { -- file tree padding
           condition = function(self)
             self.winid = vim.api.nvim_tabpage_list_wins(0)[1]
-            return status.condition.buffer_matches(
-              { filetype = { "aerial", "dapui_.", "dap-repl", "neo%-tree", "NvimTree", "edgy", "undotree" } },
-              vim.api.nvim_win_get_buf(self.winid)
-            )
+            return status.condition.buffer_matches({
+              filetype = {
+                "NvimTree",
+                "OverseerList",
+                "aerial",
+                "dap-repl",
+                "dapui_.",
+                "edgy",
+                "neo%-tree",
+                "undotree",
+              },
+            }, vim.api.nvim_win_get_buf(self.winid))
           end,
           provider = function(self) return string.rep(" ", vim.api.nvim_win_get_width(self.winid) + 1) end,
           hl = { bg = "tabline_bg" },


### PR DESCRIPTION

## 📑 Description

Adds tabline padding to overseer, doesn't interfere with `direction=bottom`

<img width="1792" alt="image" src="https://github.com/AstroNvim/AstroNvim/assets/56745535/268df5fe-5b28-4bf1-9657-3c75891b0a1c">


## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
None
