### PR TITLE
fix(provider): invalid buffer id in terminal buffer

### DIFF
--- a/lua/astronvim/utils/status/provider.lua
+++ b/lua/astronvim/utils/status/provider.lua
@@ -330,7 +330,7 @@ end
 -- @see astronvim.utils.status.utils.stylize
 function M.unique_path(opts)
   opts = extend_tbl({
-    buf_name = function(bufnr) return vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":t") end,
+    buf_name = function(bufnr) return vim.fn.fnamemodify(pcall(vim.api.nvim_buf_get_name, bufnr), ":t") end,
     bufnr = 0,
     max_length = 16,
   }, opts)


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Silences errors when exiting vertical/horizontal split terminal opened manually (e.g. `:horizontal terminal`)

## ℹ Additional Information
![Screen Recording 2023-09-09 at 6 36 42 AM](https://github.com/AstroNvim/AstroNvim/assets/56745535/f964e7f0-8d11-4802-a377-a0b3c6267f93)


