### PR TITLE
feat(utils): add `is_loaded` to check whether a plugin has been loaded

### DIFF
--- a/lua/astronvim/utils/init.lua
+++ b/lua/astronvim/utils/init.lua
@@ -223,6 +223,17 @@ function M.is_available(plugin)
   return lazy_config_avail and lazy_config.spec.plugins[plugin] ~= nil
 end
 
+--- Check if a plugin has been loaded by lazy. Useful for conditionally evaluating heirline providers when a plugin is loaded
+---@param plugin string The plugin to search for
+---@return boolean available # Whether the plugin has been loaded
+function M.is_loaded(plugin)
+  local lazy_config_avail, lazy_config = pcall(require, "lazy.core.config")
+  if lazy_config_avail and lazy_config.plugins[plugin] then
+    if type(lazy_config.plugins[plugin]._.loaded) == "table" then return true end
+  end
+  return false
+end
+
 --- Resolve the options table for a given plugin with lazy
 ---@param plugin string The plugin to search for
 ---@return table opts # The plugin options


### PR DESCRIPTION
## 📑 Description

I wanted to create a heirline component that reports the status of a plugin, but I didn't want it to require the plugin if it wasn't already loaded since that completely messes up lazy-loading. It would be pretty convenient to include a helper function that checks this so that it can be used as a heirline condition.

## ℹ Additional Information

None
