### PR TITLE
feat(mappings): Added keybindings for swapping lines above or below

### DIFF
--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -30,6 +30,14 @@ maps.n["<C-s>"] = { "<cmd>w!<cr>", desc = "Force write" }
 maps.n["<C-q>"] = { "<cmd>qa!<cr>", desc = "Force quit" }
 maps.n["|"] = { "<cmd>vsplit<cr>", desc = "Vertical Split" }
 maps.n["\\"] = { "<cmd>split<cr>", desc = "Horizontal Split" }
+maps.n["]e"] = {
+  function() vim.cmd ":move +1<CR>" end,
+  desc = "Swap current line with the line above",
+}
+maps.n["[e"] = {
+  function() vim.cmd ":move -2<CR>" end,
+  desc = "Swap current line with the line below",
+}
 -- TODO: Remove when dropping support for <Neovim v0.10
 if not vim.ui.open then maps.n["gx"] = { utils.system_open, desc = "Open the file under cursor with system app" } end
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description
Added keybindings for swapping current line with the line above or below.
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
`[e` swaps the current line with the line above,
`]e` swaps the current line with the line below,

Note: Although, I could not find any of the following but:- The keybinding may be used elsewhere or may be planned for a future use case or; The same functionality may be provided by a different keybinding.
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->