### PR TITLE
fix(plugins): update `nvim-ts-context-commentstring` config

### DIFF
--- a/lua/astronvim/options.lua
+++ b/lua/astronvim/options.lua
@@ -62,6 +62,7 @@ local options = astronvim.user_opts("options", {
     semantic_tokens_enabled = true, -- enable or disable LSP semantic tokens on startup
     ui_notifications_enabled = true, -- disable notifications (TODO: rename to  notifications_enabled in AstroNvim v4)
     git_worktrees = nil, -- enable git integration for detached worktrees (specify a table where each entry is of the form { toplevel = vim.env.HOME, gitdir=vim.env.HOME .. "/.dotfiles" })
+    skip_ts_context_commentstring_module = true, -- skip backwards compatibility routines of JoosepAlviste/nvim-ts-context-commentstring
   },
   t = vim.t.bufs and vim.t.bufs or { bufs = vim.api.nvim_list_bufs() }, -- initialize buffers for the current tab
 })

--- a/lua/plugins/core.lua
+++ b/lua/plugins/core.lua
@@ -101,6 +101,12 @@ return {
     end,
   },
   {
+    "JoosepAlviste/nvim-ts-context-commentstring",
+    opts = {
+      enable_autocmd = false,
+    },
+  },
+  {
     "akinsho/toggleterm.nvim",
     cmd = { "ToggleTerm", "TermExec" },
     opts = {

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -36,7 +36,6 @@ return {
   opts = function()
     return {
       autotag = { enable = true },
-      context_commentstring = { enable = true, enable_autocmd = false },
       -- HACK: force install of shipped neovim parsers since TSUpdate doesn't correctly update them
       ensure_installed = {
         "bash",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
A [breaking change](https://github.com/JoosepAlviste/nvim-ts-context-commentstring/commit/5b02387b28a79c61b7d406c2a33d4db1d8454f53) happened and we have to make changes to `JoosepAlviste/nvim-ts-context-commentstring` configurations as guided by the author. See [the README](https://github.com/JoosepAlviste/nvim-ts-context-commentstring#getting-started) for more info.

This commit fixes below warning and associated trace-back notification for me:
> context_commentstring nvim-treesitter module is deprecated, use use require('ts_context_commentstring').setup {} and set vim.g.skip_ts_context_commentstring_module = true to speed up loading instead.
> This feature will be removed in ts_context_commentstring version in the future