### PR TITLE
fix(plugin): force tabline option 

### DIFF
--- a/lua/astronvim/options.lua
+++ b/lua/astronvim/options.lua
@@ -28,7 +28,6 @@ vim.opt.relativenumber = true -- show relative numberline
 vim.opt.shiftwidth = 2 -- number of space inserted for indentation
 vim.opt.shortmess:append { s = true, I = true } -- disable search count wrap and startup messages
 vim.opt.showmode = false -- disable showing modes in command line
-vim.opt.showtabline = 2 -- always display tabline
 vim.opt.signcolumn = "yes" -- always show the sign column
 vim.opt.smartcase = true -- case sensitive searching
 vim.opt.splitbelow = true -- splitting a new window below the current one

--- a/lua/astronvim/plugins/heirline.lua
+++ b/lua/astronvim/plugins/heirline.lua
@@ -41,6 +41,9 @@ return {
       end,
     },
   },
+  init = function()
+    vim.o.showtabline = 2
+  end,
   opts = function()
     local status = require "astroui.status"
     return {


### PR DESCRIPTION
Heirline is always displayed as an empty winbar area, but tabs are not drawn when 'showtabline' is 0, causing Heirline to show an empty, buggy, and flickering winbar.

The solution seems "obvious" - disable Heirline - but this component is very tightly coupled with Astronvim; disabling it will definitely break something somewhere, and suddenly all hell breaks loose.

So let's do the next "best" thing, which is enforcing 'showtabline,' disregarding user options. If they really want to disable Heirline, they shall do so by overriding the plugin configuration but at this point, they will be held responsible. \;) 