### PR TITLE
Update cmp.lua

### DIFF
--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -87,8 +87,6 @@ return {
           ["<Tab>"] = cmp.mapping(function(fallback)
             if cmp.visible() then
               cmp.select_next_item()
-            elseif luasnip.expand_or_jumpable() then
-              luasnip.expand_or_jump()
             elseif has_words_before() then
               cmp.complete()
             else


### PR DESCRIPTION
Removing this fixes tab behavior on empty new lines in braces.


## 📑 Description

<!-- Add a brief description of the pr -->

Started using AstroVim and was confused that in insert mode sometimes hitting tab causes change in visual mode and jump of cursor. Apparently this is caused by this line in cmp config.

## ℹ Additional Information

