### PR TITLE
fix(cmp): only jump through snippet locally

### DIFF
--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -87,7 +87,7 @@ return {
           ["<Tab>"] = cmp.mapping(function(fallback)
             if cmp.visible() then
               cmp.select_next_item()
-            elseif luasnip.expand_or_jumpable() then
+            elseif luasnip.expand_or_locally_jumpable() then
               luasnip.expand_or_jump()
             elseif has_words_before() then
               cmp.complete()


### PR DESCRIPTION
Bugs Fixed:
- Hitting tab can jump to previously completed snippet from anywhere in the same file

Other:
This PR changes the snippet jump action to only be executed when the cursor is inside the current snippet.

Previously, when e.g. trying to indent a black line using tab an incomplete jumped through previous snippet would result in an unexpected jump to that snippet.

Please let me know if this was a desired behaviour and the selection between local and global snippet jumps should be configurable instead.
