### PR TITLE
refactor(utils): create find_config_files function as file helper utility

### DIFF
--- a/lua/astronvim/mappings.lua
+++ b/lua/astronvim/mappings.lua
@@ -255,28 +255,8 @@ if is_available "telescope.nvim" then
   maps.n["<leader>f'"] = { function() require("telescope.builtin").marks() end, desc = "Find marks" }
   maps.n["<leader>f/"] =
     { function() require("telescope.builtin").current_buffer_fuzzy_find() end, desc = "Find words in current buffer" }
-  maps.n["<leader>fa"] = {
-    function()
-      local cwd = vim.fn.stdpath "config" .. "/.."
-      local search_dirs = {}
-      for _, dir in ipairs(astronvim.supported_configs) do -- search all supported config locations
-        if dir == astronvim.install.home then dir = dir .. "/lua/user" end -- don't search the astronvim core files
-        if vim.fn.isdirectory(dir) == 1 then table.insert(search_dirs, dir) end -- add directory to search if exists
-      end
-      if vim.tbl_isempty(search_dirs) then -- if no config folders found, show warning
-        utils.notify("No user configuration files found", vim.log.levels.WARN)
-      else
-        if #search_dirs == 1 then cwd = search_dirs[1] end -- if only one directory, focus cwd
-        require("telescope.builtin").find_files {
-          prompt_title = "Config Files",
-          search_dirs = search_dirs,
-          cwd = cwd,
-          follow = true,
-        } -- call telescope
-      end
-    end,
-    desc = "Find AstroNvim config files",
-  }
+  maps.n["<leader>fa"] =
+    { function() require("astronvim.utils.file").find_config_files() end, desc = "Find AstroNvim config files" }
   maps.n["<leader>fb"] = { function() require("telescope.builtin").buffers() end, desc = "Find buffers" }
   maps.n["<leader>fc"] = { function() require("telescope.builtin").grep_string() end, desc = "Find word under cursor" }
   maps.n["<leader>fC"] = { function() require("telescope.builtin").commands() end, desc = "Find commands" }

--- a/lua/astronvim/utils/file.lua
+++ b/lua/astronvim/utils/file.lua
@@ -1,0 +1,35 @@
+--- ### AstroNvim File Utilities
+--
+-- File related utility functions
+--
+-- This module can be loaded with `local file_utils = require "astronvim.utils.file"`
+--
+-- @module astronvim.utils.file
+-- @copyright 2024
+-- @license GNU General Public License v3.0
+
+local M = {}
+local utils = require "astronvim.utils"
+
+--- Find AstroNvim config files
+function M.find_config_files()
+  local cwd = vim.fn.stdpath "config" .. "/.."
+  local search_dirs = {}
+  for _, dir in ipairs(astronvim.supported_configs) do -- search all supported config locations
+    if dir == astronvim.install.home then dir = dir .. "/lua/user" end -- don't search the astronvim core files
+    if vim.fn.isdirectory(dir) == 1 then table.insert(search_dirs, dir) end -- add directory to search if exists
+  end
+  if vim.tbl_isempty(search_dirs) then -- if no config folders found, show warning
+    utils.notify("No user configuration files found", vim.log.levels.WARN)
+  else
+    if #search_dirs == 1 then cwd = search_dirs[1] end -- if only one directory, focus cwd
+    require("telescope.builtin").find_files {
+      prompt_title = "Config Files",
+      search_dirs = search_dirs,
+      cwd = cwd,
+      follow = true,
+    } -- call telescope
+  end
+end
+
+return M


### PR DESCRIPTION
I needed this function in my custom configuration but it was not possible to call it. So I created a new utils module named `file` and moved it to there.

Let me know if you prefer to have it somewhere else.

Thanks!
