### PR TITLE
fix(neo-tree): faster open triggered by o

### DIFF
--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -70,6 +70,7 @@ return {
             state.commands.open(state)
           end
         end,
+        open = function(state) state.commands.open(state) end,
         copy_selector = function(state)
           local node = state.tree:get_node()
           local filepath = node:get_id()


### PR DESCRIPTION
## 📑 Description

- Opening a file in neo-tree with `o` is much slower than opening with `l` or `enter`.
- Create an explicit `open` command triggered by `o`. It's as performant as the `child_or_open` command triggered by `l`.