### PR TITLE
feat(options): enable confirm by default

### DIFF
--- a/lua/astronvim/plugins/_astrocore_options.lua
+++ b/lua/astronvim/plugins/_astrocore_options.lua
@@ -8,6 +8,7 @@ return {
     opt.clipboard = "unnamedplus" -- connection to the system clipboard
     opt.cmdheight = 0 -- hide command line unless needed
     opt.completeopt = { "menu", "menuone", "noselect" } -- Options for insert mode completion
+    opt.confirm = true -- raise a dialog asking if you wish to save the current file(s)
     opt.copyindent = true -- copy the previous indentation on autoindenting
     opt.cursorline = true -- highlight the text line of the cursor
     opt.diffopt = vim.list_extend(vim.opt.diffopt:get(), { "algorithm:histogram", "linematch:60" }) -- enable linematch diff algorithm


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Enable [confirm](https://neovim.io/doc/user/options.html#'confirm') by default so that certain operations that would normally fail because of unsaved changes to a buffer, e.g., ":q" and ":e", instead raise a dialog asking users if they wish to save the current file(s)

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
![image](https://github.com/AstroNvim/AstroNvim/assets/91024200/db3362da-ec21-419f-abec-96c1327b4b21)
