### PR TITLE
fix(which-key): handle cmdheight properly

### DIFF
--- a/lua/astronvim/plugins/which-key.lua
+++ b/lua/astronvim/plugins/which-key.lua
@@ -5,4 +5,16 @@ return {
     icons = { group = vim.g.icons_enabled ~= false and "" or "+", separator = "" },
     disable = { filetypes = { "TelescopePrompt" } },
   },
+  config = function(_, opts)
+    local wk = require "which-key"
+    local show = wk.show
+    wk.show = function(keys, opts)
+      if vim.o.cmdheight == 1 then return show(keys, opts) end
+      vim.o.cmdheight = 1
+      vim.cmd.redraw()
+      show(keys, opts)
+      vim.schedule(function() vim.o.cmdheight = 0 end)
+    end
+    wk.setup { opts }
+  end,
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

When WhichKey draws its trail in cmdline area, having cmdheight set to 0 leads to an incorrect state where both wk's trails and heirline are not properly drawn. The strategy here is to intercept wk.show to toggle cmdheight state. That is, temporarily set cmdheight to 1 during wk.show execution and use a scheduled callback to reset it back to 0 when we're done.

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

### Before
[Screencast from 2024-03-07 11-48-34.webm](https://github.com/AstroNvim/AstroNvim/assets/91024200/7a39c80f-429e-4910-bfbe-616799ad6849)

### After
[Screencast from 2024-03-07 11-49-55.webm](https://github.com/AstroNvim/AstroNvim/assets/91024200/f0eb8337-c1ca-43a3-83ac-bfc170269460)




