### PR TITLE
fix(dap): add nvim-nio dependency to nvim-dap-ui

### DIFF
--- a/lua/astronvim/plugins/dap.lua
+++ b/lua/astronvim/plugins/dap.lua
@@ -32,6 +32,7 @@ return {
             maps.v["<Leader>dE"] = { function() require("dapui").eval() end, desc = "Evaluate Input" }
           end,
         },
+        { "nvim-neotest/nvim-nio" },
       },
       opts = { floating = { border = "rounded" } },
       config = function(...) require "astronvim.plugins.configs.nvim-dap-ui"(...) end,


### PR DESCRIPTION
## 📑 Description

Since recently, `nvim-dap-ui` started requiring an `nvim-nio` installation as a dependency (https://github.com/rcarriga/nvim-dap-ui/pull/311). Consequently, this causes an error to appear whenever the first file is opened in nvim.
 
<img width="1351" alt="Screenshot 2024-03-18 at 17 39 22" src="https://github.com/AstroNvim/AstroNvim/assets/32168861/44935982-f429-494a-bae6-b04b5deecd17">

This PR adds `nvim-nio` as a dependency of `nvim-dap-ui` and fixes this issue.

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
New dependency — `nvim-nio` as a dependency of `nvim-dap-ui`
