### PR TITLE
fix(telescope): load treesitter with telescope

### DIFF
--- a/lua/astronvim/plugins/telescope.lua
+++ b/lua/astronvim/plugins/telescope.lua
@@ -8,6 +8,7 @@ return {
       enabled = vim.fn.executable "make" == 1,
       build = "make",
     },
+    { "nvim-treesitter/nvim-treesitter" },
     {
       "AstroNvim/astrocore",
       opts = function(_, opts)


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
-->
Fixes an issue where the telescope previewer does not use treesitter (e.g. when starting up nvim with an empty buffer).

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

N/A
