### PR TITLE
Close neo-tree if its open before saving session with `resession`

### DIFF
--- a/lua/astronvim/plugins/resession.lua
+++ b/lua/astronvim/plugins/resession.lua
@@ -32,6 +32,8 @@ return {
               local buf_utils = require "astrocore.buffer"
               local autosave = buf_utils.sessions.autosave
               if autosave and buf_utils.is_valid_session() then
+                -- Safely attempt to close Neo-tree if it's open
+                pcall(function() require("neo-tree").close_all() end)
                 local save = require("resession").save
                 if autosave.last then save("Last Session", { notify = false }) end
                 if autosave.cwd then save(vim.fn.getcwd(), { dir = "dirsession", notify = false }) end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Neovim with `resession` resumes to a blank buffer whenever `neo-tree` is open whilst session was saved (when quitting neovim).
> I seem to remember this issue in V3 at some point but have not seen this occur for the past few months.

- [x] Add pcall to close all `neo-tree` in `resession.lua`

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Seems like this could be unrelated config `neo-tree` spilling into `resession.lua`. My other thought was with autocmds but I played around with putting an autocmd in `init.lua` presumably to get it loaded first but it didn't seem to work out.