### PR TITLE
fix(cmp): update `vim.snippet` to use updated `active` API

### DIFF
--- a/lua/astronvim/plugins/cmp_luasnip.lua
+++ b/lua/astronvim/plugins/cmp_luasnip.lua
@@ -75,7 +75,7 @@ return {
           ["<Tab>"] = cmp.mapping(function(fallback)
             if cmp.visible() then
               cmp.select_next_item()
-            elseif vim.snippet and vim.snippet.jumpable(1) then
+            elseif vim.snippet and vim.snippet.active { direction = 1 } then
               vim.schedule(function() vim.snippet.jump(1) end)
             elseif has_words_before() then
               cmp.complete()
@@ -86,7 +86,7 @@ return {
           ["<S-Tab>"] = cmp.mapping(function(fallback)
             if cmp.visible() then
               cmp.select_prev_item()
-            elseif vim.snippet and vim.snippet.jumpable(-1) then
+            elseif vim.snippet and vim.snippet.active { direction = -1 } then
               vim.schedule(function() vim.snippet.jump(-1) end)
             else
               fallback()


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

This will update the internal usage of `vim.snippet` to match the new API for `vim.snippet.active` as proposed here:

- https://github.com/neovim/neovim/pull/28560

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
