### PR TITLE
doc: update the update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,9 @@ Run `:Lazy clean` to remove any disabled or unused plugins
 
 Run `:Lazy sync` to update and clean plugins
 
-#### Update AstroNvim
-
-Run `:AstroUpdate` to get the latest updates from the repository<br>
-
 #### Update AstroNvim Packages
 
-Run `:AstroUpdatePackages` (`<leader>pa`) to update both Neovim plugins and Mason packages
+Run `:AstroUpdate` (`<leader>pa`) to update both Neovim plugins and Mason packages
 
 ## 🗒️ Links
 


### PR DESCRIPTION
## 📑 Description

it looks like with the release of 4.0, AstroUpdatePackages was removed and AstroUpdate does the same thing (it calls astrocore and updates everything)
