### PR TITLE
refactor(options): set shiftwidth to automatically copy 'tabstop' value

### DIFF
--- a/lua/astronvim/plugins/_astrocore_options.lua
+++ b/lua/astronvim/plugins/_astrocore_options.lua
@@ -27,7 +27,7 @@ return {
     opt.preserveindent = true -- preserve indent structure as much as possible
     opt.pumheight = 10 -- height of the pop up menu
     opt.relativenumber = true -- show relative numberline
-    opt.shiftwidth = 2 -- number of space inserted for indentation
+    opt.shiftwidth = 0 -- number of space inserted for indentation; when zero the 'tabstop' value will be used
     opt.shortmess = vim.tbl_deep_extend("force", vim.opt.shortmess:get(), { s = true, I = true }) -- disable search count wrap and startup messages
     opt.showmode = false -- disable showing modes in command line
     opt.showtabline = 2 -- always display tabline


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

When ['shiftwidth'](https://neovim.io/doc/user/options.html#'shiftwidth') is zero, the ['tabstop'](https://neovim.io/doc/user/options.html#'tabstop') value will be used, so we can avoid one extra step when changing the number of spaces that a `<Tab>` in the file counts for

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
