### PR TITLE
perf(guess-indent): improve lazy loading of guess-indent

### DIFF
--- a/lua/astronvim/lazy_snapshot.lua
+++ b/lua/astronvim/lazy_snapshot.lua
@@ -6,7 +6,7 @@ return {
   { "JoosepAlviste/nvim-ts-context-commentstring", commit = "cb064386e667def1d241317deed9fd1b38f0dc2e", optional = true },
   { "L3MON4D3/LuaSnip", version = "^2", optional = true },
   { "MunifTanjim/nui.nvim", version = "^0.3", optional = true },
-  { "NMAC427/guess-indent.nvim", commit = "b8ae749fce17aa4c267eec80a6984130b94f80b2", optional = true },
+  { "NMAC427/guess-indent.nvim", commit = "6c75506e71836f34fe5c5efa322dfce3e0494e7b", optional = true },
   { "NvChad/nvim-colorizer.lua", commit = "85855b38011114929f4058efc97af1059ab3e41d", optional = true },
   { "RRethy/vim-illuminate", commit = "5eeb7951fc630682c322e88a9bbdae5c224ff0aa", optional = true },
   { "akinsho/toggleterm.nvim", version = "^2", optional = true },

--- a/lua/astronvim/plugins/configs/guess-indent.lua
+++ b/lua/astronvim/plugins/configs/guess-indent.lua
@@ -1,4 +1,2 @@
-return function(_, opts)
-  require("guess-indent").setup(opts)
-  vim.cmd.lua { args = { "require('guess-indent').set_from_buffer('auto_cmd')" }, mods = { silent = true } }
-end
+-- TODO: AstroNvim v5 delete this unused file
+return function(_, opts) require("guess-indent").setup(opts) end

--- a/lua/astronvim/plugins/guess-indent.lua
+++ b/lua/astronvim/plugins/guess-indent.lua
@@ -1,5 +1,30 @@
 return {
   "NMAC427/guess-indent.nvim",
-  event = "User AstroFile",
-  config = function(...) require "astronvim.plugins.configs.guess-indent"(...) end,
+  cmd = "GuessIndent",
+  dependencies = {
+    "AstroNvim/astrocore",
+    opts = {
+      autocmds = {
+        GuessIndent = {
+          {
+            event = "BufReadPost",
+            desc = "Guess indentation when loading a file",
+            callback = function(args) require("guess-indent").set_from_buffer(args.buf, true, true) end,
+          },
+          {
+            event = "BufNewFile",
+            desc = "Guess indentation when saving a new file",
+            callback = function(args)
+              vim.api.nvim_create_autocmd("BufWritePost", {
+                buffer = args.buf,
+                once = true,
+                callback = function(wargs) require("guess-indent").set_from_buffer(wargs.buf, true, true) end,
+              })
+            end,
+          },
+        },
+      },
+    },
+  },
+  opts = { auto_cmd = false },
 }


### PR DESCRIPTION
This reverts commit 3d094ea7a6dafa90ac7bf6f48ffb399b28c22b12.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

Waiting on:

- https://github.com/NMAC427/guess-indent.nvim/pull/20

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
