### PR TITLE
fix(telescope): ensure `.git` folders are always ignored on Windows

### DIFF
--- a/lua/astronvim/plugins/telescope.lua
+++ b/lua/astronvim/plugins/telescope.lua
@@ -124,7 +124,7 @@ return {
     end
     return {
       defaults = {
-        file_ignore_patterns = { "^%.git/", "/%.git/" },
+        file_ignore_patterns = { "^%.git[/\\]", "[/\\]%.git[/\\]" },
         git_worktrees = require("astrocore").config.git_worktrees,
         prompt_prefix = get_icon("Selected", 1),
         selection_caret = get_icon("Selected", 1),


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

A follow-up of 016c2cfc5288118f315a7fb26082d90d86a529b6 by ensuring `.git` folders are properly excluded from Telescope search results on Windows machines.

The original Regex file patterns of `"^%.git/"` and `"/%.git/"` could not match Git folders on Windows because Windows uses backward slashes (`\`) instead of forward slashes. 

## ℹ Additional Information

Steps to reproduce:
1. Install AstroNvim on a Windows machine
2. Clone this repo
3. Run `:Telescope find_files`
4. Search for the word `.git`

- Before: `.git\*` files will show up
- After: The Git files are hidden

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/55f6b71f-9e60-4459-9d51-d89473652563) | ![image](https://github.com/user-attachments/assets/97dcdd34-2bec-4cd5-a6fc-2b1f490d8c0a)
