### PR TITLE
fix(mapping): shorten the description of gx

### DIFF
--- a/lua/astronvim/plugins/_astrocore_mappings.lua
+++ b/lua/astronvim/plugins/_astrocore_mappings.lua
@@ -42,7 +42,7 @@ return {
     maps.n["\\"] = { "<Cmd>split<CR>", desc = "Horizontal Split" }
     -- TODO: remove deprecated method check after dropping support for neovim v0.9
     if not vim.ui.open then
-      local gx_desc = "Opens filepath or URI under cursor with the system handler (file explorer, web browser, …)"
+      local gx_desc = "System-open path under cursor"
       maps.n["gx"] = { function() astro.system_open(vim.fn.expand "<cfile>") end, desc = gx_desc }
       maps.x["gx"] = {
         function()


### PR DESCRIPTION
## 📑 Description

The description of `gx` is too long and `which-key` can only display in 1-col mode. This PR fixes this.

Before:
<img width="1021" alt="Screenshot 2024-09-27 at 2 25 46 PM" src="https://github.com/user-attachments/assets/dba2b5c7-27ee-4715-8229-4ee7e2834eb2">

After
<img width="963" alt="Screenshot 2024-09-27 at 2 26 11 PM" src="https://github.com/user-attachments/assets/b52bc168-cc56-4f2f-89cc-02221b6f5a26">
