### PR TITLE
feat(gitsigns): close preview_hunk window with q

### DIFF
--- a/lua/astronvim/plugins/gitsigns.lua
+++ b/lua/astronvim/plugins/gitsigns.lua
@@ -45,6 +45,14 @@ return {
           maps[mode]["ig"] = { ":<C-U>Gitsigns select_hunk<CR>", desc = "inside Git hunk" }
         end
 
+        maps.n["q"] = {
+          function()
+            for _, id in ipairs((vim.api.nvim_list_wins())) do
+              if vim.api.nvim_win_get_config(id).relative ~= "" then vim.api.nvim_win_close(id, false) end
+            end
+          end
+        }
+
         astrocore.set_mappings(maps, { buffer = bufnr })
       end,
       worktrees = require("astrocore").config.git_worktrees,

--- a/lua/astronvim/plugins/gitsigns.lua
+++ b/lua/astronvim/plugins/gitsigns.lua
@@ -50,7 +50,7 @@ return {
             for _, id in ipairs((vim.api.nvim_list_wins())) do
               if vim.api.nvim_win_get_config(id).relative ~= "" then vim.api.nvim_win_close(id, false) end
             end
-          end
+          end,
         }
 
         astrocore.set_mappings(maps, { buffer = bufnr })


### PR DESCRIPTION
## 📑 Description

Closing the `preview_hunk` window is normally done by moving the cursor. I've found this to be disruptive at times so went ahead and added a mapping to close the window with `q`.  Of course, one could argue this is the wrong place to add such a binding as closing any window like this via a standard key like `q` would offer the most benefit being scoped elsewhere. Obviously, that's a call for the Jedi to make...

Scooped this little gem [here](https://github.com/lewis6991/gitsigns.nvim/issues/385#issuecomment-1635543223)