### PR TITLE
fix(_astrolsp): use correct key when indexing file_operations table

### DIFF
--- a/lua/astronvim/plugins/_astrolsp.lua
+++ b/lua/astronvim/plugins/_astrolsp.lua
@@ -59,7 +59,7 @@ return {
               event = event,
               id = "astrolsp_" .. operation,
               handler = function(args)
-                require("astrolsp.file_operations")[module](config.args and config.args(args) or args)
+                require("astrolsp.file_operations")[operation](config.args and config.args(args) or args)
               end,
             })
           end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
Replace the incorrect reference of `module` with `operation` in the file operations event handler.

- [x] Fixed variable reference from `module` to `operation` in the handler function.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ℹ Additional Information
--
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
