### PR TITLE
feat(options): use the new `winborder` option to set floating window style

### DIFF
--- a/lua/astronvim/plugins/_astrocore.lua
+++ b/lua/astronvim/plugins/_astrocore.lua
@@ -62,7 +62,8 @@ return {
           float = {
             focused = false,
             style = "minimal",
-            border = "rounded",
+            -- TODO: remove when dropping support for Neovim v0.10
+            border = vim.fn.has "nvim-0.11" == 0 and "rounded" or nil,
             source = true,
             header = "",
             prefix = "",

--- a/lua/astronvim/plugins/_astrocore_options.lua
+++ b/lua/astronvim/plugins/_astrocore_options.lua
@@ -7,6 +7,7 @@ return {
     if vim.fn.has "nvim-0.11" == 1 then
       -- TODO: remove check when dropping support for Neovim v0.10
       opt.tabclose = "uselast" -- go to last used tab when closing the current tab
+      opt.winborder = "rounded" -- set default winborder to rounded
     end
 
     opt.backspace = vim.list_extend(vim.opt.backspace:get(), { "nostop" }) -- don't stop backspace at insert

--- a/lua/astronvim/plugins/_astrolsp.lua
+++ b/lua/astronvim/plugins/_astrolsp.lua
@@ -13,11 +13,13 @@ return {
     config = {},
     defaults = {
       hover = {
-        border = "rounded",
+        -- TODO: remove when dropping support for Neovim v0.10
+        border = vim.fn.has "nvim-0.11" == 0 and "rounded" or nil,
         silent = true,
       },
       signature_help = {
-        border = "rounded",
+        -- TODO: remove when dropping support for Neovim v0.10
+        border = vim.fn.has "nvim-0.11" == 0 and "rounded" or nil,
         silent = true,
         focusable = false,
       },

--- a/lua/astronvim/plugins/blink.lua
+++ b/lua/astronvim/plugins/blink.lua
@@ -119,7 +119,8 @@ return {
       list = { selection = { preselect = false, auto_insert = true } },
       menu = {
         auto_show = function(ctx) return ctx.mode ~= "cmdline" end,
-        border = "rounded",
+        -- TODO: remove when dropping support for Neovim v0.10
+        border = vim.fn.has "nvim-0.11" == 0 and "rounded" or nil,
         winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:PmenuSel,Search:None",
         draw = {
           treesitter = { "lsp" },
@@ -138,14 +139,16 @@ return {
         auto_show = true,
         auto_show_delay_ms = 0,
         window = {
-          border = "rounded",
+          -- TODO: remove when dropping support for Neovim v0.10
+          border = vim.fn.has "nvim-0.11" == 0 and "rounded" or nil,
           winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder,CursorLine:PmenuSel,Search:None",
         },
       },
     },
     signature = {
       window = {
-        border = "rounded",
+        -- TODO: remove when dropping support for Neovim v0.10
+        border = vim.fn.has "nvim-0.11" == 0 and "rounded" or nil,
         winhighlight = "Normal:NormalFloat,FloatBorder:FloatBorder",
       },
     },

--- a/lua/astronvim/plugins/dap.lua
+++ b/lua/astronvim/plugins/dap.lua
@@ -90,7 +90,10 @@ return {
         },
       },
       dependencies = { { "nvim-neotest/nvim-nio", lazy = true } },
-      opts = { floating = { border = "rounded" } },
+      opts = {
+        -- TODO: remove when dropping support for Neovim v0.10
+        floating = vim.fn.has "nvim-0.11" == 0 and { border = "rounded" } or nil,
+      },
       config = function(...) require "astronvim.plugins.configs.nvim-dap-ui"(...) end,
     },
     {

--- a/lua/astronvim/plugins/toggleterm.lua
+++ b/lua/astronvim/plugins/toggleterm.lua
@@ -99,6 +99,7 @@ return {
       end
     end,
     shading_factor = 2,
-    float_opts = { border = "rounded" },
+    -- TODO: remove when dropping support for Neovim v0.10
+    float_opts = vim.fn.has "nvim-0.11" == 0 and { border = "rounded" } or nil,
   },
 }


### PR DESCRIPTION

## 📑 Description

This migrates to utilizing the `'winborder'` option added in Neovim v0.11 for globally setting the default floating window border to `"rounded"`. This helps create a unified user interface and a single location for users to change the general style of the editor.

## ℹ Additional Information

At the moment a ton of plugins have various levels of hard coded values  for their window creation, so it's not a good idea to merge this quite yet. But we should keep an eye out on the ecosystem to see when is a good time to roll this out.
