### PR TITLE
feat(snacks): add find in dir commands for neo-tree

### DIFF
--- a/lua/astronvim/plugins/snacks.lua
+++ b/lua/astronvim/plugins/snacks.lua
@@ -211,13 +211,35 @@ return {
       optional = true,
       opts = {
         commands = {
-          find_in_dir = function(state)
+          find_files_in_dir = function(state)
             local node = state.tree:get_node()
             local path = node.type == "file" and node:get_parent_id() or node:get_id()
             require("snacks").picker.files { cwd = path }
           end,
+          find_all_files_in_dir = function(state)
+            local node = state.tree:get_node()
+            local path = node.type == "file" and node:get_parent_id() or node:get_id()
+            require("snacks").picker.files { cwd = path, hidden = true, ignored = true }
+          end,
+          find_words_in_dir = function(state)
+            local node = state.tree:get_node()
+            local path = node.type == "file" and node:get_parent_id() or node:get_id()
+            require("snacks").picker.grep { cwd = path }
+          end,
+          find_all_words_in_dir = function(state)
+            local node = state.tree:get_node()
+            local path = node.type == "file" and node:get_parent_id() or node:get_id()
+            require("snacks").picker.grep { cwd = path, hidden = true, ignored = true }
+          end,
         },
-        window = { mappings = { F = "find_in_dir" } },
+        window = {
+          mappings = {
+            ff = "find_files_in_dir",
+            fF = "find_all_files_in_dir",
+            fw = vim.fn.executable "rg" == 1 and "find_words_in_dir" or nil,
+            fW = vim.fn.executable "rg" == 1 and "find_all_words_in_dir" or nil,
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

Expanding on #2067, following the key mappings set for `snacks.nvim` - dashboard:

- https://github.com/AstroNvim/AstroNvim/blob/fb1ccede6dbf278cfe9cec5b17999ec6e1b3aa06/lua/astronvim/plugins/snacks.lua#L161-L172
- https://github.com/AstroNvim/AstroNvim/blob/fb1ccede6dbf278cfe9cec5b17999ec6e1b3aa06/lua/astronvim/plugins/snacks.lua#L185-L191

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
