### PR TITLE
feat(snacks): add undo history picker

### DIFF
--- a/lua/astronvim/plugins/snacks.lua
+++ b/lua/astronvim/plugins/snacks.lua
@@ -205,6 +205,7 @@ return {
               desc = "Find words in all files",
             }
           end
+          maps.n["<Leader>fu"] = { function() require("snacks").picker.undo() end, desc = "Find undo history" }
           maps.n["<Leader>lD"] = { function() require("snacks").picker.diagnostics() end, desc = "Search diagnostics" }
           maps.n["<Leader>ls"] = {
             function()


### PR DESCRIPTION
## 📑 Description

Added the snacks undo history picker, which uses the same keybind as the teloscope plugin 
https://github.com/AstroNvim/astrocommunity/blob/main/lua/astrocommunity/editing-support/telescope-undo-nvim/init.lua
