### PR TITLE
fix(highlight-colors): fix typo in config option

### DIFF
--- a/lua/astronvim/plugins/highlight-colors.lua
+++ b/lua/astronvim/plugins/highlight-colors.lua
@@ -10,7 +10,7 @@ return {
     end,
   },
   opts = {
-    enabled_named_colors = false,
+    enable_named_colors = false,
     virtual_symbol = "󱓻",
     exclude_buffer = function(bufnr)
       local buf_utils = require "astrocore.buffer"


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

The `highlight-colors`'s config was trying to disable `enabled_named_colors`, but according to the plugin's docs it's spelled as `enable_named_colors` (without a final `d` in `enable`) which lead to the config being ignored. This PR fixes the name of the setting

<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
