### PR TITLE
fix(heirline): fix tabline close tab icon not being highlighted

### DIFF
--- a/lua/astronvim/plugins/heirline.lua
+++ b/lua/astronvim/plugins/heirline.lua
@@ -121,7 +121,7 @@ return {
           },
           { -- close button for current tab
             provider = status.provider.close_button { kind = "TabClose", padding = { left = 1, right = 1 } },
-            hl = status.hl.get_attributes("tab_close", true),
+            hl = function() return status.hl.get_attributes("tab_close", true) end,
             on_click = {
               callback = function() require("astrocore.buffer").close_tab() end,
               name = "heirline_tabline_close_tab_callback",


### PR DESCRIPTION
## 📑 Description

Fixes the tab close icon in the tabline not being highlighted

AstroUI's `get_attributes` function checks that the highlight name has been loaded into heirline already and discards it otherwise. However, colors aren't loaded into heirline until after the opts function has run, so we need to defer the check by wrapping the call to `get_attributes` in a function
