### PR TITLE
fix(snacks): Fix Snacks notifier icons

### DIFF
--- a/lua/astronvim/plugins/snacks.lua
+++ b/lua/astronvim/plugins/snacks.lua
@@ -46,11 +46,11 @@ return {
     -- configure notifier
     opts.notifier = {}
     opts.notifier.icons = {
-      DEBUG = get_icon "Debugger",
-      ERROR = get_icon "DiagnosticError",
-      INFO = get_icon "DiagnosticInfo",
-      TRACE = get_icon "DiagnosticHint",
-      WARN = get_icon "DiagnosticWarn",
+      debug = get_icon "Debugger",
+      error = get_icon "DiagnosticError",
+      info = get_icon "DiagnosticInfo",
+      trace = get_icon "DiagnosticHint",
+      warn = get_icon "DiagnosticWarn",
     }
 
     -- configure picker and `vim.ui.select`


### PR DESCRIPTION
From the [Snacks notifier documentation](https://github.com/folke/snacks.nvim/blob/main/docs/notifier.md), it looks like the keys to the `icons` table should be lowercase. Changing them fixes an issue where the icons take up two spaces instead of one.

Before:

<img width="616" height="213" alt="SCR-20250720-lfxn" src="https://github.com/user-attachments/assets/e491105b-da91-4de8-a9f7-ba47f6c670d5" />

After:

<img width="608" height="209" alt="SCR-20250720-lrkc-2" src="https://github.com/user-attachments/assets/0e934d00-f894-4148-949e-a41670493751" />