### PR TITLE
feat(heirline): make close button optional via astroui status config

### DIFF
--- a/lua/astronvim/plugins/_astroui.lua
+++ b/lua/astronvim/plugins/_astroui.lua
@@ -36,6 +36,9 @@ return {
   ---@type AstroUIOpts
   opts = {
     colorscheme = "astrotheme",
+    status = {
+      show_close_button = true, -- enable close button in tabline by default
+    },
     folding = {
       enabled = function(bufnr) return require("astrocore.buffer").is_valid(bufnr) end,
       methods = { "lsp", "treesitter", "indent" },

--- a/lua/astronvim/plugins/heirline.lua
+++ b/lua/astronvim/plugins/heirline.lua
@@ -128,14 +128,16 @@ return {
             provider = status.provider.tabnr(),
             hl = function(self) return status.hl.get_attributes(status.heirline.tab_type(self, "tab"), true) end,
           },
-          vim.tbl_get(ui_config, "status", "show_close_button") ~= false and { -- close button for current tab
-            provider = status.provider.close_button { kind = "TabClose", padding = { left = 1, right = 1 } },
-            hl = cached_func(status.hl.get_attributes, "tab_close", true),
-            on_click = {
-              callback = function() require("astrocore.buffer").close_tab() end,
-              name = "heirline_tabline_close_tab_callback",
-            },
-          } or nil,
+          vim.tbl_get(ui_config, "status", "show_close_button") ~= false
+              and { -- close button for current tab
+                provider = status.provider.close_button { kind = "TabClose", padding = { left = 1, right = 1 } },
+                hl = cached_func(status.hl.get_attributes, "tab_close", true),
+                on_click = {
+                  callback = function() require("astrocore.buffer").close_tab() end,
+                  name = "heirline_tabline_close_tab_callback",
+                },
+              }
+            or nil,
         },
       },
       statuscolumn = {

--- a/lua/astronvim/plugins/heirline.lua
+++ b/lua/astronvim/plugins/heirline.lua
@@ -128,14 +128,14 @@ return {
             provider = status.provider.tabnr(),
             hl = function(self) return status.hl.get_attributes(status.heirline.tab_type(self, "tab"), true) end,
           },
-          { -- close button for current tab
+          vim.tbl_get(ui_config, "status", "show_close_button") ~= false and { -- close button for current tab
             provider = status.provider.close_button { kind = "TabClose", padding = { left = 1, right = 1 } },
             hl = cached_func(status.hl.get_attributes, "tab_close", true),
             on_click = {
               callback = function() require("astrocore.buffer").close_tab() end,
               name = "heirline_tabline_close_tab_callback",
             },
-          },
+          } or nil,
         },
       },
       statuscolumn = {

--- a/lua/astronvim/plugins/heirline.lua
+++ b/lua/astronvim/plugins/heirline.lua
@@ -55,6 +55,7 @@ return {
   opts = function(_, opts)
     local status = require "astroui.status"
     local ui_config = require("astroui").config
+    local show_close_button = vim.tbl_get(ui_config, "status", "show_close_button") ~= false
     local cached_func = function(func, ...)
       local cached
       local args = { ... }
@@ -128,16 +129,15 @@ return {
             provider = status.provider.tabnr(),
             hl = function(self) return status.hl.get_attributes(status.heirline.tab_type(self, "tab"), true) end,
           },
-          vim.tbl_get(ui_config, "status", "show_close_button") ~= false
-              and { -- close button for current tab
-                provider = status.provider.close_button { kind = "TabClose", padding = { left = 1, right = 1 } },
-                hl = cached_func(status.hl.get_attributes, "tab_close", true),
-                on_click = {
-                  callback = function() require("astrocore.buffer").close_tab() end,
-                  name = "heirline_tabline_close_tab_callback",
-                },
-              }
-            or nil,
+          show_close_button
+            and {
+              provider = status.provider.close_button { kind = "TabClose", padding = { left = 1, right = 1 } },
+              hl = cached_func(status.hl.get_attributes, "tab_close", true),
+              on_click = {
+                callback = function() require("astrocore.buffer").close_tab() end,
+                name = "heirline_tabline_close_tab_callback",
+              },
+            },
         },
       },
       statuscolumn = {


### PR DESCRIPTION
This PR adds the ability to disable the close button in the tabline via the astroui status configuration.

The close button can be disabled by setting `show_close_button = false` in the astroui status configuration. By default, it is enabled to maintain backward compatibility.

Changes:
- Added `show_close_button` option to astroui status configuration (default: true)
- Modified heirline tabline to respect the configuration option

See https://github.com/AstroNvim/astroui/pull/63