### PR TITLE
fix(blink): fix missing snippet icon when use `lspkind` symbols

### DIFF
--- a/lua/astronvim/plugins/blink.lua
+++ b/lua/astronvim/plugins/blink.lua
@@ -34,7 +34,7 @@ local function get_kind_icon(CTX)
             local icon = lspkind.symbolic(ctx.kind, { mode = "symbol" })
             if icon then ctx.kind_icon = icon end
           elseif ctx.item.source_name == "Snippets" then
-            local icon = lspkind.symbolic("snippet", { mode = "symbol" })
+            local icon = lspkind.symbolic("Snippet", { mode = "symbol" })
             if icon then ctx.kind_icon = icon end
           end
         end


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below
Closes #<Issue # here>
-->

## 📑 Description

<!-- Add a brief description of the pr -->
Fix no snippet icon in blink.cmp when use `lspkind` symbols
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## 📖 Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
- before

<img width="306" height="328" alt="Screenshot 2025-09-26 at 11 05 41" src="https://github.com/user-attachments/assets/20a7c3af-c694-4da4-b176-af9905302f66" />


- after

<img width="301" height="310" alt="Screenshot 2025-09-26 at 11 32 20" src="https://github.com/user-attachments/assets/4adb75e1-3305-446b-8256-448120bceccf" />
