### PR TITLE
docs: fix typos, admonition rendering, and outdated version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ if not vim.uv.fs_stat(lazypath) then
 end
 vim.opt.rtp:prepend(lazypath)
 
-require("lazy").setup { "AstroNvim/AstroNvim", version = "^5", import = "astronvim.plugins" }
+require("lazy").setup { "AstroNvim/AstroNvim", version = "^6", import = "astronvim.plugins" }
 ```
 
 ## 📦 Basic Setup

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ AstroNvim is an aesthetically pleasing and feature-rich neovim config that is ex
   - [Python](https://www.python.org/) - python repl toggle terminal (`<leader>tp`)
   - [Node](https://nodejs.org/en/) - node repl toggle terminal (`<leader>tn`)
 
-> [!NOTE] > <sup id="1">[1]</sup> All downloadable Nerd Fonts contain icons which are used by AstroNvim. Install the Nerd Font of your choice to your system and in your terminal emulator settings, set its font face to that Nerd Font. If you are using AstroNvim on a remote system via SSH, you do not need to install the font on the remote system.
+> [!NOTE]
+> <sup id="1">[1]</sup> All downloadable Nerd Fonts contain icons which are used by AstroNvim. Install the Nerd Font of your choice to your system and in your terminal emulator settings, set its font face to that Nerd Font. If you are using AstroNvim on a remote system via SSH, you do not need to install the font on the remote system.
 
-> [!NOTE] > <sup id="2">[2]</sup> Note when using default theme: For MacOS, the default terminal does not have true color support. You will need to use [iTerm2](https://iterm2.com/), [Kitty](https://sw.kovidgoyal.net/kitty/), [WezTerm](https://wezterm.org), or another [terminal emulator](https://github.com/termstandard/colors?tab=readme-ov-file#truecolor-support-in-output-devices) that has true color support.
+> [!NOTE]
+> <sup id="2">[2]</sup> Note when using default theme: For MacOS, the default terminal does not have true color support. You will need to use [iTerm2](https://iterm2.com/), [Kitty](https://sw.kovidgoyal.net/kitty/), [WezTerm](https://wezterm.org), or another [terminal emulator](https://github.com/termstandard/colors?tab=readme-ov-file#truecolor-support-in-output-devices) that has true color support.
 
 ## 🛠️ Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
   <img
     src="https://astronvim.com/logo/astronvim.svg"
     width="110"
-    ,
     height="100"
   />
 </div>
@@ -47,7 +46,7 @@ AstroNvim is an aesthetically pleasing and feature-rich neovim config that is ex
 - File explorer with [Neo-tree](https://github.com/nvim-neo-tree/neo-tree.nvim)
 - Autocompletion with [Blink.cmp](https://github.com/saghen/blink.cmp)
 - Git integration with [Gitsigns](https://github.com/lewis6991/gitsigns.nvim)
-- Statusline, Winbar, and Bufferline, Statuscolumn with [Heirline](https://github.com/rebelot/heirline.nvim)
+- Statusline, Winbar, Bufferline, and Statuscolumn with [Heirline](https://github.com/rebelot/heirline.nvim)
 - Terminal with [Toggleterm](https://github.com/akinsho/toggleterm.nvim)
 - Fuzzy finding with [Snacks Picker](https://github.com/folke/snacks.nvim/blob/main/docs/picker.md)
 - Syntax highlighting with [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
@@ -119,7 +118,7 @@ nvim
 
 #### Minimal `~/.config/nvim/init.lua`
 
-Some user's might not want to use an entire template or do any customization. Here is a minimal `~/.config/nvim/init.lua` file that simply set's up a base AstroNvim installation:
+Some users might not want to use an entire template or do any customization. Here is a minimal `~/.config/nvim/init.lua` file that simply sets up a base AstroNvim installation:
 
 ```lua
 local lazypath = vim.fn.stdpath "data" .. "/lazy/lazy.nvim"


### PR DESCRIPTION
Three small README fixes:

- `[!NOTE]` admonitions were written on a single line together with the following text, so GitHub renders them as literal `[!NOTE] >` text instead of callouts. This restores the fix from #2602, which had regressed.
- Typos: `Some user's` -> `Some users`, `set's up` -> `sets up`, a stray comma inside the logo `<img>` tag, and a misplaced conjunction in the Heirline feature list (`Statusline, Winbar, and Bufferline, Statuscolumn`).
- The minimal `init.lua` example still pins `version = "^5"` while the current major version is v6, so users copying the snippet install the previous major version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)