### PR TITLE
fix: correct typos in comments and user-facing descriptions

### DIFF
--- a/lua/astronvim/health.lua
+++ b/lua/astronvim/health.lua
@@ -37,7 +37,7 @@ function M.check()
     {
       cmd = { "rg" },
       type = "warn",
-      msg = "Used for Pickers `live_grep` picker, `<Leader>fw` and `<Leader>fW` by default (Optional)",
+      msg = "Used for the `live_grep` picker, `<Leader>fw` and `<Leader>fW` by default (Optional)",
     },
     { cmd = { "lazygit" }, type = "warn", msg = "Used for mappings to pull up git TUI (Optional)" },
     { cmd = { "node" }, type = "warn", msg = "Used for mappings to pull up node REPL (Optional)" },

--- a/lua/astronvim/plugins/_astrocore.lua
+++ b/lua/astronvim/plugins/_astrocore.lua
@@ -45,7 +45,7 @@ return {
           cmp = true, -- enable completion at start
           diagnostics = true, -- enable diagnostics by default
           highlighturl = true, -- highlight URLs by default
-          notifications = true, -- disable notifications
+          notifications = true, -- enable notifications
         },
         diagnostics = {
           virtual_text = true,

--- a/lua/astronvim/plugins/_astrocore_autocmds.lua
+++ b/lua/astronvim/plugins/_astrocore_autocmds.lua
@@ -25,7 +25,7 @@ return {
       auto_quit = {
         {
           event = "BufEnter",
-          desc = "Quit AstroNvim if more than one window is open and only sidebar windows are list",
+          desc = "Quit AstroNvim if more than one window is open and only sidebar windows are left",
           callback = function()
             local wins = vim.api.nvim_tabpage_list_wins(0)
             -- neo-tree handles if there is only a single window left

--- a/lua/astronvim/plugins/_astrocore_mappings.lua
+++ b/lua/astronvim/plugins/_astrocore_mappings.lua
@@ -4,7 +4,7 @@ return {
   opts = function(_, opts)
     local astro = require "astrocore"
     local get_icon = require("astroui").get_icon
-    -- initialize internally use mapping section titles
+    -- initialize internally used mapping section titles
     opts._map_sections = {
       f = { desc = get_icon("Search", 1, true) .. "Find" },
       p = { desc = get_icon("Package", 1, true) .. "Packages" },

--- a/lua/astronvim/plugins/dap.lua
+++ b/lua/astronvim/plugins/dap.lua
@@ -85,7 +85,7 @@ return {
             }
             maps.n["<Leader>du"] = { function() require("dapui").toggle() end, desc = "Toggle Debugger UI" }
             maps.n["<Leader>dh"] = { function() require("dap.ui.widgets").hover() end, desc = "Debugger Hover" }
-            maps.v["<Leader>dE"] = { function() require("dapui").eval() end, desc = "Evaluate Input" }
+            maps.v["<Leader>dE"] = { function() require("dapui").eval() end, desc = "Evaluate Selection" }
           end,
         },
       },

--- a/lua/astronvim/plugins/neo-tree.lua
+++ b/lua/astronvim/plugins/neo-tree.lua
@@ -122,7 +122,7 @@ return {
           if node:has_children() then
             if not node:is_expanded() then -- if unexpanded, expand
               state.commands.toggle_node(state)
-            else -- if expanded and has children, seleect the next child
+            else -- if expanded and has children, select the next child
               if node.type == "file" then
                 state.commands.open(state)
               else

--- a/lua/astronvim/plugins/snacks.lua
+++ b/lua/astronvim/plugins/snacks.lua
@@ -124,7 +124,7 @@ return {
         local maps = opts.mappings
         local snack_opts = require("astrocore").plugin_opts "snacks.nvim"
 
-        -- Snacks.dashboard mappins
+        -- Snacks.dashboard mappings
         maps.n["<Leader>h"] = {
           function()
             if vim.bo.filetype == "snacks_dashboard" then


### PR DESCRIPTION
Typo and wording fixes, split into one commit per concern:

- Code comments: `mappins` -> `mappings` (snacks.lua), `seleect` -> `select` (neo-tree.lua), `internally use` -> `internally used` (_astrocore_mappings.lua), and a contradictory `-- disable notifications` comment on a feature whose value is `true` (_astrocore.lua).
- `auto_quit` autocmd description: "only sidebar windows are list" -> "are left" (visible in `:autocmd` listings).
- Visual mode `<Leader>dE` description: `dapui.eval()` with no argument evaluates the visual selection and never prompts, so "Evaluate Input" -> "Evaluate Selection".
- `:checkhealth astronvim` ripgrep message: "Used for Pickers `live_grep` picker" -> "Used for the `live_grep` picker" (leftover from removing Telescope references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)