### PR TITLE
fix(astrocore): correct Makefile capitalization in rooter detector

### DIFF
--- a/lua/astronvim/plugins/_astrocore.lua
+++ b/lua/astronvim/plugins/_astrocore.lua
@@ -73,7 +73,7 @@ return {
         },
         rooter = {
           enabled = true,
-          detector = { "lsp", { ".git", "_darcs", ".hg", ".bzr", ".svn" }, { "lua", "MakeFile", "package.json" } },
+          detector = { "lsp", { ".git", "_darcs", ".hg", ".bzr", ".svn" }, { "lua", "Makefile", "package.json" } },
           ignore = {
             servers = {},
             dirs = {},


### PR DESCRIPTION
The rooter fallback detector lists `"MakeFile"`, which never matches a real `Makefile` on case-sensitive filesystems, so projects rooted only by a Makefile are not detected on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)