### PR TITLE
perf: migrate more vim functions to Lua APIs

### DIFF
--- a/lua/astronvim/health.lua
+++ b/lua/astronvim/health.lua
@@ -13,7 +13,7 @@ function M.check()
   health.start "Checking requirements"
 
   health.info("AstroNvim Version: " .. require("astronvim").version())
-  health.info("Neovim Version: v" .. vim.fn.matchstr(vim.fn.execute "version", "NVIM v\\zs[^\n]*"))
+  health.info("Neovim Version: v" .. vim.api.nvim_exec2("version", { output = true }).output:match "NVIM v([^\n]*)")
 
   if vim.version().prerelease then
     health.warn "Neovim nightly is not officially supported and may have breaking changes"

--- a/lua/astronvim/plugins/_astrolsp.lua
+++ b/lua/astronvim/plugins/_astrolsp.lua
@@ -49,8 +49,7 @@ return {
               event = "BufWritePre",
               desc = "trigger willCreateFiles before writing a new file",
               callback = function(args)
-                local filename = require("astrocore.buffer").is_valid(args.buf)
-                  and vim.fn.expand("#" .. args.buf .. ":p")
+                local filename = require("astrocore.buffer").is_valid(args.buf) and vim.api.nvim_buf_get_name(args.buf)
                 if filename and not vim.uv.fs_stat(filename) then
                   vim.b[args.buf].new_file = filename
                   require("astrolsp.file_operations").willCreateFiles(filename)

--- a/lua/astronvim/plugins/snacks.lua
+++ b/lua/astronvim/plugins/snacks.lua
@@ -189,7 +189,7 @@ return {
           maps.n["<Leader>ff"] = {
             function()
               require("snacks").picker.files {
-                hidden = vim.tbl_get((vim.uv or vim.loop).fs_stat ".git" or {}, "type") == "directory",
+                hidden = vim.tbl_get(vim.uv.fs_stat ".git" or {}, "type") == "directory",
               }
             end,
             desc = "Find files",


### PR DESCRIPTION
Continues 2946f98 by migrating the remaining straightforward cases:

- health.lua: `vim.fn.matchstr(vim.fn.execute "version", ...)` -> `vim.api.nvim_exec2("version", { output = true }).output:match(...)`. Output is byte-identical; `tostring(vim.version())` is not a substitute because it appends build metadata on release builds.
- _astrolsp.lua: `vim.fn.expand("#" .. args.buf .. ":p")` -> `vim.api.nvim_buf_get_name(args.buf)` (both return the full path, and `""` for unnamed buffers); matches the idiom already used in _astrocore_autocmds.lua and neo-tree.lua.
- snacks.lua: drop the `(vim.uv or vim.loop)` fallback — `vim.uv` always exists on the minimum supported Neovim 0.11, and this was the last remaining `vim.loop` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)