### PR TITLE
refactor: remove obsolete Neovim <0.11 compatibility code

### DIFF
--- a/lua/astronvim/plugins/_astrocore_mappings.lua
+++ b/lua/astronvim/plugins/_astrocore_mappings.lua
@@ -46,18 +46,6 @@ return {
 
     maps.n["<Leader>R"] = { function() require("astrocore").rename_file() end, desc = "Rename file" }
 
-    -- Neovim Default LSP Mappings
-    if vim.fn.has "nvim-0.11" ~= 1 then
-      maps.n["gra"] = { function() vim.lsp.buf.code_action() end, desc = "vim.lsp.buf.code_action()" }
-      maps.x["gra"] = { function() vim.lsp.buf.code_action() end, desc = "vim.lsp.buf.code_action()" }
-      maps.n["grn"] = { function() vim.lsp.buf.rename() end, desc = "vim.lsp.buf.rename()" }
-      maps.n["grr"] = { function() vim.lsp.buf.references() end, desc = "vim.lsp.buf.references()" }
-      maps.n["gri"] = { function() vim.lsp.buf.implementation() end, desc = "vim.lsp.buf.implementation()" }
-      maps.n["gO"] = { function() vim.lsp.buf.document_symbol() end, desc = "vim.lsp.buf.document_symbol()" }
-      maps.i["<C-S>"] = { function() vim.lsp.buf.signature_help() end, desc = "vim.lsp.buf.signature_help()" }
-      maps.s["<C-S>"] = { function() vim.lsp.buf.signature_help() end, desc = "vim.lsp.buf.signature_help()" }
-    end
-
     -- Plugin Manager
     maps.n["<Leader>p"] = vim.tbl_get(sections, "p")
     maps.n["<Leader>pi"] = { function() require("lazy").install() end, desc = "Plugins Install" }

--- a/lua/astronvim/plugins/_astrocore_mappings.lua
+++ b/lua/astronvim/plugins/_astrocore_mappings.lua
@@ -126,17 +126,6 @@ return {
     maps.n["<Leader>x"] = vim.tbl_get(sections, "x")
     maps.n["<Leader>xq"] = { "<Cmd>copen<CR>", desc = "Quickfix List" }
     maps.n["<Leader>xl"] = { "<Cmd>lopen<CR>", desc = "Location List" }
-    if vim.fn.has "nvim-0.11" == 0 then
-      maps.n["]q"] = { vim.cmd.cnext, desc = "Next quickfix" }
-      maps.n["[q"] = { vim.cmd.cprev, desc = "Previous quickfix" }
-      maps.n["]Q"] = { vim.cmd.clast, desc = "End quickfix" }
-      maps.n["[Q"] = { vim.cmd.cfirst, desc = "Beginning quickfix" }
-
-      maps.n["]l"] = { vim.cmd.lnext, desc = "Next loclist" }
-      maps.n["[l"] = { vim.cmd.lprev, desc = "Previous loclist" }
-      maps.n["]L"] = { vim.cmd.llast, desc = "End loclist" }
-      maps.n["[L"] = { vim.cmd.lfirst, desc = "Beginning loclist" }
-    end
 
     -- Stay in indent mode
     maps.v["<S-Tab>"] = { "<gv", desc = "Unindent line" }

--- a/lua/astronvim/plugins/_astrolsp_mappings.lua
+++ b/lua/astronvim/plugins/_astrolsp_mappings.lua
@@ -86,12 +86,12 @@ return {
     maps.n["<Leader>uh"] = {
       function() require("astrolsp.toggles").buffer_inlay_hints() end,
       desc = "Toggle LSP inlay hints (buffer)",
-      cond = vim.lsp.inlay_hint and "textDocument/inlayHint" or false,
+      cond = "textDocument/inlayHint",
     }
     maps.n["<Leader>uH"] = {
       function() require("astrolsp.toggles").inlay_hints() end,
       desc = "Toggle LSP inlay hints (global)",
-      cond = vim.lsp.inlay_hint and "textDocument/inlayHint" or false,
+      cond = "textDocument/inlayHint",
     }
 
     maps.n["<Leader>lR"] =
@@ -126,9 +126,7 @@ return {
     maps.n["<Leader>uY"] = {
       function() require("astrolsp.toggles").buffer_semantic_tokens() end,
       desc = "Toggle LSP semantic highlight (buffer)",
-      cond = function(client)
-        return client:supports_method "textDocument/semanticTokens/full" and vim.lsp.semantic_tokens
-      end,
+      cond = function(client) return client:supports_method "textDocument/semanticTokens/full" end,
     }
     opts.mappings = require("astrocore").extend_tbl(opts.mappings, maps)
   end,


### PR DESCRIPTION
`astronvim.init()` refuses to start on anything below Neovim 0.11, so these compatibility paths are unreachable:

- The `vim.fn.has "nvim-0.11" ~= 1` backport of the default LSP mappings (gra/grn/grr/gri/gO/`<C-S>`) — these are Neovim built-in defaults on 0.11+.
- The `vim.fn.has "nvim-0.11" == 0` backport of the quickfix/loclist mappings (`]q`/`[q`/`]l`/`[l` and friends) — also built-in defaults on 0.11+.
- Existence checks on `vim.lsp.inlay_hint` (0.10+) and `vim.lsp.semantic_tokens` (0.9+) in mapping conditions, which can no longer change the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)