### PR TITLE
docs: fix lua-language-server annotations

### DIFF
--- a/lua/astronvim/config.lua
+++ b/lua/astronvim/config.lua
@@ -3,6 +3,7 @@
 ---@field maplocalleader string? the local leader key to map before setting up Lazy
 ---@field icons_enabled boolean? whether to enable icons, default to `true`
 ---@field pin_plugins boolean? whether to pin plugins or not, if `nil` then will pin if version is set.
+---@field update_notification boolean? whether to notify to re-run `:Lazy update` after pinned plugin updates, default to `true`
 
 ---@type AstroNvimOpts
 return {

--- a/lua/astronvim/notify.lua
+++ b/lua/astronvim/notify.lua
@@ -16,8 +16,8 @@ local paused = false
 ---@return boolean # whether or not the notifications are paused
 function M.is_paused() return paused end
 
---- Check now many notifications are pending
----@return table[] # the number of pending notifications
+--- Check how many notifications are pending
+---@return table[] # the pending notifications
 function M.pending() return notifications end
 
 --- Pause notifications
@@ -34,8 +34,8 @@ end
 
 --- A pausable `vim.notify` function
 ---@param message string|string[] Notification message
----@param level string|number Log level. See vim.log.levels
----@param opts notify.Options Notification options
+---@param level? string|number Log level. See vim.log.levels
+---@param opts? table Notification options
 function M.notify(message, level, opts)
   if M.is_paused() then
     local pos = opts and opts.replace
@@ -50,7 +50,7 @@ function M.notify(message, level, opts)
 end
 
 --- Set `vim.notify` to extend it to be pause-able
----@param notify? function|notify the original notification function (defaults to `vim.notify`)
+---@param notify? function the original notification function (defaults to `vim.notify`)
 function M.setup(notify)
   if not notify then notify = vim.notify end
   assert(notify ~= M.notify, "vim.notify is already setup")


### PR DESCRIPTION
Two lua-language-server facing fixes:

- notify.lua: the `notify.Options` and `notify` types came from rcarriga/nvim-notify, which is no longer part of the distribution, so lua-language-server reports them as undefined. `level` and `opts` are also marked optional to match how `vim.notify` is called (the body already guards against nil). Also fixes a "Check now many" -> "Check how many" typo, and the `@return` doc which described a count while the function returns the pending notifications themselves.
- config.lua: `update_notification` is read in the AstroNvim `build` step but was missing from the `AstroNvimOpts` class, so there is no completion for it and lua-language-server flags it as an unknown field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)