### PR TITLE
refactor: remove redundant checks and lookups

### DIFF
--- a/lua/astronvim/init.lua
+++ b/lua/astronvim/init.lua
@@ -9,7 +9,7 @@ function M.version()
   local plugin = assert(astrocore.get_plugin "AstroNvim")
   local version_ok, version_str = pcall(astrocore.read_file, plugin.dir .. "/version.txt")
   if not version_ok then
-    require("astrocore").notify("Unable to calculate version", vim.log.levels.ERROR)
+    astrocore.notify("Unable to calculate version", vim.log.levels.ERROR)
     return
   end
 
@@ -20,7 +20,7 @@ function M.version()
     if vim.fn.executable "git" == 1 then
       local git_description = astrocore.cmd({ "git", "-C", plugin.dir, "describe", "--tags" }, false)
       if git_description then
-        local nightly_version = git_description and git_description:match ".*(-%d+-g%x+)\n*$"
+        local nightly_version = git_description:match ".*(-%d+-g%x+)\n*$"
         if nightly_version then version_str = version_str .. nightly_version end
       end
     end

--- a/lua/astronvim/plugins/_astrocore_autocmds.lua
+++ b/lua/astronvim/plugins/_astrocore_autocmds.lua
@@ -236,7 +236,7 @@ return {
           desc = "Restore last cursor position when opening a file",
           callback = function(args)
             local buf = args.buf
-            if vim.b[buf].last_loc_restored or vim.tbl_contains({ "gitcommit" }, vim.bo[buf].filetype) then return end
+            if vim.b[buf].last_loc_restored or vim.bo[buf].filetype == "gitcommit" then return end
             vim.b[buf].last_loc_restored = true
             local mark = vim.api.nvim_buf_get_mark(buf, '"')
             if mark[1] > 0 and mark[1] <= vim.api.nvim_buf_line_count(buf) then
@@ -265,7 +265,7 @@ return {
           elseif mode == "r" then -- always enable highlight search in replace mode
             new_hlsearch = true
           -- enable highlight search when searching in command mode
-          elseif mode == "c" and vim.tbl_contains({ "<CR>" }, vim.fn.keytrans(char)) then
+          elseif mode == "c" and vim.fn.keytrans(char) == "<CR>" then
             local cmd = vim.fn.getcmdline()
             if (cmd:match "^s" or cmd:match "^%%s" or cmd:match "^'<,'>s") and vim.o.incsearch then
               new_hlsearch = true

--- a/lua/astronvim/plugins/blink.lua
+++ b/lua/astronvim/plugins/blink.lua
@@ -52,7 +52,7 @@ local function get_kind_icon(CTX)
         if ctx.item.kind == kinds.Color then
           local doc = vim.tbl_get(ctx, "item", "documentation")
           if doc then
-            local color_item = highlight_colors_avail and highlight_colors.format(doc, { kind = kinds[kinds.Color] })
+            local color_item = highlight_colors.format(doc, { kind = kinds[kinds.Color] })
             if color_item and color_item.abbr_hl_group then
               if color_item.abbr then ctx.kind_icon = color_item.abbr end
               ctx.kind_hl = color_item.abbr_hl_group

--- a/lua/astronvim/plugins/heirline.lua
+++ b/lua/astronvim/plugins/heirline.lua
@@ -66,7 +66,7 @@ return {
     end
     return require("astrocore").extend_tbl(opts, {
       opts = {
-        colors = require("astroui").config.status.setup_colors(),
+        colors = ui_config.status.setup_colors(),
         disable_winbar_cb = function(args)
           local enabled = vim.tbl_get(ui_config, "status", "winbar", "enabled")
           if enabled and status.condition.buffer_matches(enabled, args.buf) then return false end


### PR DESCRIPTION
Small cleanups removing provably redundant code, one commit per concern:

- blink.lua: the highlight provider closure is only created inside the `if highlight_colors_avail then` branch, so re-checking the captured upvalue is always true.
- init.lua: reuse the `astrocore` local already required at the top of `M.version`, and drop a `git_description and` nil-check that the enclosing `if git_description then` already guarantees.
- heirline.lua: reuse the `ui_config` local defined a few lines above instead of `require("astroui").config` again — it points at the exact same table.
- _astrocore_autocmds.lua: `vim.tbl_contains` over a one-element list is a plain equality test; the direct comparison avoids allocating a throwaway table in the `BufReadPost` callback and the `on_key` handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)