### PR TITLE
chore(ts-autotag): remove orphaned config file

### DIFF
--- a/lua/astronvim/plugins/configs/ts-autotag.lua
+++ b/lua/astronvim/plugins/configs/ts-autotag.lua
@@ -1,4 +1,0 @@
-return function(_, opts)
-  require("nvim-ts-autotag").setup(opts)
-  require("astrocore").exec_buffer_autocmds("FileType", { group = "nvim_ts_xmltag" })
-end


### PR DESCRIPTION
`lua/astronvim/plugins/configs/ts-autotag.lua` lost its only caller in 7c6ff2e when the custom `config` function was dropped from the nvim-ts-autotag spec; nothing references the file anymore (every other file in `configs/` is referenced by exactly one plugin spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)