### PR TITLE
chore(highlight-colors): normalize `specs` to a list-like table

### DIFF
--- a/lua/astronvim/plugins/highlight-colors.lua
+++ b/lua/astronvim/plugins/highlight-colors.lua
@@ -3,11 +3,13 @@ return {
   event = { "User AstroFile", "InsertEnter" },
   cmd = "HighlightColors",
   specs = {
-    "AstroNvim/astrocore",
-    opts = function(_, opts)
-      local maps = opts.mappings
-      maps.n["<Leader>uz"] = { function() vim.cmd.HighlightColors "Toggle" end, desc = "Toggle color highlight" }
-    end,
+    {
+      "AstroNvim/astrocore",
+      opts = function(_, opts)
+        local maps = opts.mappings
+        maps.n["<Leader>uz"] = { function() vim.cmd.HighlightColors "Toggle" end, desc = "Toggle color highlight" }
+      end,
+    },
   },
   opts = {
     enable_named_colors = false,


### PR DESCRIPTION
Every other `specs` block in the repo uses a list of spec tables since c6ab4e8 normalized them; highlight-colors.lua (added later) was the only remaining flat single-spec table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)