### PR TITLE
chore(astrocore): use vim.o when setting hlsearch

### DIFF
--- a/lua/astronvim/plugins/_astrocore_autocmds.lua
+++ b/lua/astronvim/plugins/_astrocore_autocmds.lua
@@ -273,7 +273,7 @@ return {
           else
             return
           end
-          if vim.o.hlsearch ~= new_hlsearch then vim.opt.hlsearch = new_hlsearch end
+          if vim.o.hlsearch ~= new_hlsearch then vim.o.hlsearch = new_hlsearch end
           mid_mapping = true
           vim.schedule(function() mid_mapping = false end)
         end,


### PR DESCRIPTION
The same statement already reads the option through `vim.o`; writing through `vim.opt` creates an Option object for a plain boolean set. `vim.o` is the dominant idiom for scalar option access in the plugin configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)