### PR TITLE
fix: preserve notification and file creation state

### DIFF
--- a/lua/astronvim/notify.lua
+++ b/lua/astronvim/notify.lua
@@ -43,7 +43,14 @@ function M.notify(message, level, opts)
     local pos = opts and opts.replace
     if type(pos) == "table" and pos.id then pos = pos.id end
     if type(pos) ~= "number" or not notifications[pos] then pos = #notifications + 1 end
-    if opts then opts.replace = nil end
+    if opts then
+      local queued_opts = {}
+      for key, value in pairs(opts) do
+        queued_opts[key] = value
+      end
+      queued_opts.replace = nil
+      opts = queued_opts
+    end
     notifications[pos] = vim.F.pack_len(message, level, opts)
     return { id = pos }
   else

--- a/lua/astronvim/plugins/_astrolsp.lua
+++ b/lua/astronvim/plugins/_astrolsp.lua
@@ -49,6 +49,7 @@ return {
               event = "BufWritePre",
               desc = "trigger willCreateFiles before writing a new file",
               callback = function(args)
+                vim.b[args.buf].new_file = false
                 local filename = require("astrocore.buffer").is_valid(args.buf) and vim.api.nvim_buf_get_name(args.buf)
                 if filename and not vim.uv.fs_stat(filename) then
                   vim.b[args.buf].new_file = filename
@@ -83,7 +84,10 @@ return {
           didCreateFiles = { events = { events.FILE_ADDED } },
           willDeleteFiles = { events = { events.BEFORE_FILE_DELETE } },
           didDeleteFiles = { events = { events.FILE_DELETED } },
-          willRenameFiles = { events = { events.BEFORE_FILE_MOVE, events.BEFORE_FILE_RENAME }, args = move_args },
+          willRenameFiles = {
+            events = { events.BEFORE_FILE_MOVE, events.BEFORE_FILE_RENAME },
+            args = move_args,
+          },
           didRenameFiles = { events = { events.FILE_MOVED, events.FILE_RENAMED }, args = move_args },
         }
         for operation, config in pairs(operations) do


### PR DESCRIPTION
**Notifications**

- Copy paused notification options before removing `replace`, preserving the caller-owned table.
- Use a shallow copy so valid opaque option values such as `vim.uv` handles remain supported.

**LSP file operations**

- Clear the pending new-file marker before each `BufWritePre` check.
- Prevent a failed write from emitting a stale `didCreateFiles` notification after the buffer is renamed to an existing path.

**Validation**

- Passed StyLua, Selene, typos, Lua compilation, and diff checks.
- Passed focused regressions on Neovim 0.11.4 and 0.12.4.
