### PR TITLE
fix: harden startup and runtime integration state

### DIFF
--- a/lua/astronvim/health.lua
+++ b/lua/astronvim/health.lua
@@ -12,7 +12,7 @@ local health = vim.health
 function M.check()
   health.start "Checking requirements"
 
-  health.info("AstroNvim Version: " .. require("astronvim").version())
+  health.info("AstroNvim Version: " .. (require("astronvim").version() or "unknown"))
   health.info("Neovim Version: v" .. vim.api.nvim_exec2("version", { output = true }).output:match "NVIM v([^\n]*)")
 
   if vim.version().prerelease then

--- a/lua/astronvim/init.lua
+++ b/lua/astronvim/init.lua
@@ -42,24 +42,28 @@ function M.init()
   if M.did_init then return end
   M.did_init = true
 
-  local notify = require "astronvim.notify"
-  notify.setup()
-  notify.defer_startup()
+  local success, err = pcall(function()
+    require("astronvim.notify").defer_startup()
 
-  -- force setup during initialization
-  local plugin = require("lazy.core.config").spec.plugins.AstroNvim
+    -- force setup during initialization
+    local plugin = require("lazy.core.config").spec.plugins.AstroNvim
 
-  local opts = require("lazy.core.plugin").values(plugin, "opts")
-  if opts.pin_plugins == nil then opts.pin_plugins = plugin.version ~= nil end
+    local opts = require("lazy.core.plugin").values(plugin, "opts")
+    if opts.pin_plugins == nil then opts.pin_plugins = plugin.version ~= nil end
 
-  ---@diagnostic disable-next-line: cast-local-type
-  opts = vim.tbl_deep_extend("force", M.config, opts)
-  ---@cast opts -nil
-  M.config = opts
+    ---@diagnostic disable-next-line: cast-local-type
+    opts = vim.tbl_deep_extend("force", M.config, opts)
+    ---@cast opts -nil
+    M.config = opts
 
-  if not vim.g.mapleader and M.config.mapleader then vim.g.mapleader = M.config.mapleader end
-  if not vim.g.maplocalleader and M.config.maplocalleader then vim.g.maplocalleader = M.config.maplocalleader end
-  if M.config.icons_enabled == false then vim.g.icons_enabled = false end
+    if not vim.g.mapleader and M.config.mapleader then vim.g.mapleader = M.config.mapleader end
+    if not vim.g.maplocalleader and M.config.maplocalleader then vim.g.maplocalleader = M.config.maplocalleader end
+    if M.config.icons_enabled == false then vim.g.icons_enabled = false end
+  end)
+  if not success then
+    M.did_init = false
+    error(err, 0)
+  end
 end
 
 function M.setup() end

--- a/lua/astronvim/notify.lua
+++ b/lua/astronvim/notify.lua
@@ -10,7 +10,28 @@ local M = {}
 
 ---@type table[]
 local notifications = {}
+local notification_ids = {}
+local notification_positions = {}
+local next_notification_id = 0
+local active_notification_id
 local paused = false
+local resuming = false
+local startup_defer
+
+local function reindex_notifications(start)
+  for position = start, #notification_ids do
+    notification_positions[notification_ids[position]] = position
+  end
+end
+
+local function new_notification_id()
+  repeat
+    next_notification_id = next_notification_id + 1
+  until not notification_positions[next_notification_id] and next_notification_id ~= active_notification_id
+  return next_notification_id
+end
+
+local function current_notify() return vim.notify == M.notify and M._original or vim.notify end
 
 --- Check if notifications are paused
 ---@return boolean # whether or not the notifications are paused
@@ -21,17 +42,49 @@ function M.is_paused() return paused end
 function M.pending() return notifications end
 
 --- Pause notifications
-function M.pause() paused = true end
+function M.pause()
+  if vim.notify ~= M.notify then
+    M._original, vim.notify = vim.notify, M.notify
+  end
+  paused = true
+end
+
+local function schedule_resume()
+  if paused or resuming or #notifications == 0 then return end
+  resuming = true
+  vim.schedule(function()
+    if paused then
+      resuming = false
+      return
+    end
+    local notify = current_notify()
+    while not paused and #notifications > 0 do
+      local notif = table.remove(notifications, 1)
+      local id = table.remove(notification_ids, 1)
+      notification_positions[id] = nil
+      reindex_notifications(1)
+      active_notification_id = id
+      local ok, err = pcall(notify, vim.F.unpack_len(notif))
+      active_notification_id = nil
+      if not ok then
+        if not notification_positions[id] then
+          table.insert(notifications, 1, notif)
+          table.insert(notification_ids, 1, id)
+          reindex_notifications(1)
+        end
+        paused = true
+        resuming = false
+        error(err, 0)
+      end
+    end
+    resuming = false
+  end)
+end
 
 --- Resume paused notifications
 function M.resume()
   paused = false
-  vim.schedule(function()
-    for _, notif in pairs(notifications) do
-      vim.notify(vim.F.unpack_len(notif))
-    end
-    notifications = {}
-  end)
+  schedule_resume()
 end
 
 --- A pausable `vim.notify` function
@@ -39,35 +92,25 @@ end
 ---@param level? string|number Log level. See vim.log.levels
 ---@param opts? table Notification options
 function M.notify(message, level, opts)
-  if M.is_paused() then
-    local pos = opts and opts.replace
-    if type(pos) == "table" and pos.id then pos = pos.id end
-    if type(pos) ~= "number" or not notifications[pos] then pos = #notifications + 1 end
-    if opts then
-      local queued_opts = {}
-      for key, value in pairs(opts) do
-        queued_opts[key] = value
-      end
-      queued_opts.replace = nil
-      opts = queued_opts
-    end
-    notifications[pos] = vim.F.pack_len(message, level, opts)
-    return { id = pos }
-  else
-    return M._original(message, level, opts)
-  end
-end
+  if not M.is_paused() and not resuming then return current_notify()(message, level, opts) end
 
---- Set `vim.notify` to extend it to be pausable
----@param notify? function the original notification function (defaults to `vim.notify`)
-function M.setup(notify)
-  if not notify then notify = vim.notify end
-  assert(notify ~= M.notify, "vim.notify is already setup")
-  M._original, vim.notify = notify, M.notify
+  local id = opts and opts.replace
+  if type(id) == "table" and id.id then id = id.id end
+  local pos = type(id) == "number" and notification_positions[id] or nil
+  if not pos then
+    if type(id) ~= "number" or id ~= active_notification_id then id = new_notification_id() end
+    pos = #notifications + 1
+    notification_ids[pos] = id
+    notification_positions[id] = pos
+  end
+  if opts then opts.replace = nil end
+  notifications[pos] = vim.F.pack_len(message, level, opts)
+  return { id = id }
 end
 
 --- Remove `astronvim.notify` utilities and restore original `vim.notify`
 function M.restore()
+  if startup_defer then startup_defer(false) end
   if vim.notify == M.notify then vim.notify = M._original end
   if M.is_paused() then M.resume() end
 end
@@ -75,22 +118,31 @@ end
 --- Pause notifications for a 500ms delay or until `vim.notify` changes
 function M.defer_startup()
   M.pause()
+  if startup_defer then startup_defer(false) end
 
   -- defer initially for 500ms or until `vim.notify` changes
-  local timer, checker = vim.uv.new_timer(), vim.uv.new_check()
+  local timer = assert(vim.uv.new_timer(), "Unable to create startup notification timer")
+  local checker = assert(vim.uv.new_check(), "Unable to create startup notification checker")
+  local complete = false
 
-  local function replay()
+  local function finish(resume)
+    if complete then return end
+    complete = true
     timer:stop()
     checker:stop()
-    M.resume()
+    timer:close()
+    checker:close()
+    if startup_defer == finish then startup_defer = nil end
+    if resume then M.resume() end
   end
+  startup_defer = finish
 
   -- wait till vim.notify has been replaced
   checker:start(function()
-    if vim.notify ~= M.notify then replay() end
+    if vim.notify ~= M.notify then finish(true) end
   end)
   -- or replay after 500ms as a fallback
-  timer:start(500, 0, replay)
+  timer:start(500, 0, function() finish(true) end)
 end
 
 return M

--- a/lua/astronvim/plugins/_astrocore_autocmds.lua
+++ b/lua/astronvim/plugins/_astrocore_autocmds.lua
@@ -136,42 +136,42 @@ return {
           desc = "AstroNvim user events for file detection (AstroFile and AstroGitFile)",
           callback = function(args)
             if vim.b[args.buf].astrofile_checked then return end
-            vim.b[args.buf].astrofile_checked = true
             vim.schedule(function()
-              if not vim.api.nvim_buf_is_valid(args.buf) then return end
+              if not vim.api.nvim_buf_is_valid(args.buf) or vim.b[args.buf].astrofile_checked then return end
               local astro = require "astrocore"
               local current_file = vim.api.nvim_buf_get_name(args.buf)
-              if vim.g.vscode or not (current_file == "" or vim.bo[args.buf].buftype == "nofile") then
-                local skip_augroups = {}
-                for _, autocmd in ipairs(vim.api.nvim_get_autocmds { event = args.event }) do
-                  if autocmd.group_name then skip_augroups[autocmd.group_name] = true end
-                end
-                skip_augroups["filetypedetect"] = false -- don't skip filetypedetect events
-                astro.event "File"
-                local folder = vim.fs.abspath(vim.fs.dirname(current_file))
-                if vim.fn.has "win32" == 1 then folder = ('"%s"'):format(folder) end
-                if vim.fn.executable "git" == 1 then
-                  if astro.cmd({ "git", "-C", folder, "rev-parse" }, false) or astro.file_worktree() then
-                    astro.event "GitFile"
-                    pcall(vim.api.nvim_del_augroup_by_name, "file_user_events")
-                  end
-                else
+              if not vim.g.vscode and (current_file == "" or vim.bo[args.buf].buftype == "nofile") then return end
+
+              vim.b[args.buf].astrofile_checked = true
+              local skip_augroups = {}
+              for _, autocmd in ipairs(vim.api.nvim_get_autocmds { event = args.event }) do
+                if autocmd.group_name then skip_augroups[autocmd.group_name] = true end
+              end
+              skip_augroups["filetypedetect"] = false -- don't skip filetypedetect events
+              astro.event "File"
+              local folder = vim.fs.abspath(vim.fs.dirname(current_file))
+              if vim.fn.has "win32" == 1 then folder = ('"%s"'):format(folder) end
+              if vim.fn.executable "git" == 1 then
+                if astro.cmd({ "git", "-C", folder, "rev-parse" }, false) or astro.file_worktree() then
+                  astro.event "GitFile"
                   pcall(vim.api.nvim_del_augroup_by_name, "file_user_events")
                 end
-                vim.schedule(function()
-                  if require("astrocore.buffer").is_valid(args.buf) then
-                    for _, autocmd in ipairs(vim.api.nvim_get_autocmds { event = args.event }) do
-                      if autocmd.group_name and not skip_augroups[autocmd.group_name] then
-                        vim.api.nvim_exec_autocmds(
-                          args.event,
-                          { group = autocmd.group_name, buffer = args.buf, data = args.data }
-                        )
-                        skip_augroups[autocmd.group_name] = true
-                      end
+              else
+                pcall(vim.api.nvim_del_augroup_by_name, "file_user_events")
+              end
+              vim.schedule(function()
+                if require("astrocore.buffer").is_valid(args.buf) then
+                  for _, autocmd in ipairs(vim.api.nvim_get_autocmds { event = args.event }) do
+                    if autocmd.group_name and not skip_augroups[autocmd.group_name] then
+                      vim.api.nvim_exec_autocmds(
+                        args.event,
+                        { group = autocmd.group_name, buffer = args.buf, data = args.data }
+                      )
+                      skip_augroups[autocmd.group_name] = true
                     end
                   end
-                end)
-              end
+                end
+              end)
             end)
           end,
         },

--- a/lua/astronvim/plugins/_astrocore_mappings.lua
+++ b/lua/astronvim/plugins/_astrocore_mappings.lua
@@ -34,7 +34,7 @@ return {
     maps.n["<Leader>Q"] = { "<Cmd>confirm qall<CR>", desc = "Exit AstroNvim" }
     maps.n["<Leader>n"] = { "<Cmd>enew<CR>", desc = "New File" }
     maps.n["<C-S>"] = { "<Cmd>silent! update! | redraw<CR>", desc = "Force write" }
-    maps.x["<C-S>"] = maps.i["<C-s>"]
+    maps.x["<C-S>"] = maps.n["<C-S>"]
     maps.n["<C-Q>"] = { "<Cmd>q!<CR>", desc = "Force quit" }
     maps.n["|"] = { "<Cmd>vsplit<CR>", desc = "Vertical Split" }
     maps.n["\\"] = { "<Cmd>split<CR>", desc = "Horizontal Split" }

--- a/lua/astronvim/plugins/_astrocore_options.lua
+++ b/lua/astronvim/plugins/_astrocore_options.lua
@@ -13,7 +13,10 @@ return {
     opt.confirm = true -- raise a dialog asking if you wish to save the current file(s)
     opt.copyindent = true -- copy the previous indentation on autoindenting
     opt.cursorline = true -- highlight the text line of the cursor
-    opt.diffopt = vim.list_extend(vim.opt.diffopt:get(), { "algorithm:histogram", "linematch:60" }) -- enable linematch diff algorithm
+    -- TODO: Remove check when dropping support for Neovim v0.12
+    opt.diffopt = vim.fn.has "nvim-0.13" == 1
+        and vim.tbl_deep_extend("force", vim.opt.diffopt:get(), { algorithm = "histogram", linematch = 60 })
+      or vim.list_extend(vim.opt.diffopt:get(), { "algorithm:histogram", "linematch:60" }) -- enable linematch diff algorithm
     opt.expandtab = true -- enable the use of space in tab
     opt.fillchars = {
       eob = " ",

--- a/lua/astronvim/plugins/_astrolsp.lua
+++ b/lua/astronvim/plugins/_astrolsp.lua
@@ -8,7 +8,7 @@ return {
   ---@type AstroLSPOpts
   opts = {
     features = {
-      codelens = not vim.version.range("0.12.0-0.12.1"):has(vim.version()),
+      codelens = not vim.version.range("0.12.0 - 0.12.1"):has(vim.version()),
       inlay_hints = false,
       semantic_tokens = true,
     },
@@ -78,12 +78,33 @@ return {
       opts = function(_, opts)
         local events = require "neo-tree.events"
         if not opts.event_handlers then opts.event_handlers = {} end
-        local move_args = function(args) return { from = args.source, to = args.destination } end
+        local deleted_paths = {}
+        local function path_kind(path)
+          local stat = vim.uv.fs_stat(path)
+          return stat and (stat.type == "directory" and "folder" or "file")
+        end
+        local function delete_args(path)
+          local typed_path = { path = path, kind = path_kind(path) or "file" }
+          deleted_paths[path] = typed_path
+          return typed_path
+        end
+        local function deleted_args(path)
+          local typed_path = deleted_paths[path] or { path = path, kind = path_kind(path) or "file" }
+          deleted_paths[path] = nil
+          return typed_path
+        end
+        local function move_args(args)
+          return {
+            from = args.source,
+            to = args.destination,
+            kind = path_kind(args.source) or path_kind(args.destination) or "file",
+          }
+        end
         local operations = {
           willCreateFiles = { events = { events.BEFORE_FILE_ADD } },
           didCreateFiles = { events = { events.FILE_ADDED } },
-          willDeleteFiles = { events = { events.BEFORE_FILE_DELETE } },
-          didDeleteFiles = { events = { events.FILE_DELETED } },
+          willDeleteFiles = { events = { events.BEFORE_FILE_DELETE }, args = delete_args },
+          didDeleteFiles = { events = { events.FILE_DELETED }, args = deleted_args },
           willRenameFiles = {
             events = { events.BEFORE_FILE_MOVE, events.BEFORE_FILE_RENAME },
             args = move_args,

--- a/lua/astronvim/plugins/_astrolsp_autocmds.lua
+++ b/lua/astronvim/plugins/_astrolsp_autocmds.lua
@@ -1,6 +1,6 @@
-local function formatting_enabled(client)
+local function formatting_enabled(client, bufnr)
   local formatting_disabled = vim.tbl_get(require("astrolsp").config, "formatting", "disabled")
-  return client:supports_method "textDocument/formatting"
+  return client:supports_method("textDocument/formatting", bufnr)
     and formatting_disabled ~= true
     and not vim.tbl_contains(formatting_disabled, client.name)
 end
@@ -67,10 +67,9 @@ return {
           desc = "autoformat on save",
           callback = function(_, _, bufnr)
             local astrolsp = require "astrolsp"
-            local autoformat = assert(astrolsp.config.formatting.format_on_save)
             local buffer_autoformat = vim.b[bufnr].autoformat
-            if buffer_autoformat == nil then buffer_autoformat = autoformat.enabled end
-            if buffer_autoformat and ((not autoformat.filter) or autoformat.filter(bufnr)) then
+            if buffer_autoformat == nil then buffer_autoformat = astrolsp.autoformat_enabled(bufnr) end
+            if buffer_autoformat then
               vim.lsp.buf.format(vim.tbl_deep_extend("force", astrolsp.format_opts, { bufnr = bufnr }))
             end
           end,

--- a/lua/astronvim/plugins/_astrolsp_mappings.lua
+++ b/lua/astronvim/plugins/_astrolsp_mappings.lua
@@ -50,9 +50,11 @@ return {
 
     local function formatting_checker(method)
       method = "textDocument/" .. (method or "formatting")
-      return function(client)
+      return function(client, bufnr)
         local disabled = opts.formatting.disabled
-        return client:supports_method(method) and disabled ~= true and not vim.tbl_contains(disabled, client.name)
+        return client:supports_method(method, bufnr)
+          and disabled ~= true
+          and not vim.tbl_contains(disabled, client.name)
       end
     end
     local formatting_enabled = formatting_checker()
@@ -126,7 +128,7 @@ return {
     maps.n["<Leader>uY"] = {
       function() require("astrolsp.toggles").buffer_semantic_tokens() end,
       desc = "Toggle LSP semantic highlight (buffer)",
-      cond = function(client) return client:supports_method "textDocument/semanticTokens/full" end,
+      cond = function(client, bufnr) return client:supports_method("textDocument/semanticTokens/full", bufnr) end,
     }
     opts.mappings = require("astrocore").extend_tbl(opts.mappings, maps)
   end,

--- a/lua/astronvim/plugins/blink.lua
+++ b/lua/astronvim/plugins/blink.lua
@@ -197,7 +197,7 @@ return {
       opts = function(_, opts)
         if not opts.config then opts.config = {} end
         if not opts.config["*"] then opts.config["*"] = {} end
-        opts.config["*"].capabilities = require("blink.cmp").get_lsp_capabilities(opts.config.capabilities)
+        opts.config["*"].capabilities = require("blink.cmp").get_lsp_capabilities(opts.config["*"].capabilities)
 
         -- disable AstroLSP signature help if `blink.cmp` is providing it
         local blink_opts = require("astrocore").plugin_opts "blink.cmp"

--- a/lua/astronvim/plugins/configs/mason-tool-installer.lua
+++ b/lua/astronvim/plugins/configs/mason-tool-installer.lua
@@ -1,5 +1,8 @@
 return function(_, opts)
   local mason_tool_installer = require "mason-tool-installer"
   mason_tool_installer.setup(opts)
-  if opts.run_on_start ~= false then mason_tool_installer.run_on_start() end
+  if opts.run_on_start ~= false and vim.v.vim_did_enter == 1 then
+    pcall(vim.api.nvim_del_augroup_by_name, "mti_start")
+    mason_tool_installer.run_on_start()
+  end
 end

--- a/lua/astronvim/plugins/dap.lua
+++ b/lua/astronvim/plugins/dap.lua
@@ -117,5 +117,5 @@ return {
       },
     },
   },
-  config = function(...) require "astronvim.plugins.configs.nvim-dap"(...) end,
+  config = function() require "astronvim.plugins.configs.nvim-dap"() end,
 }

--- a/lua/astronvim/plugins/heirline.lua
+++ b/lua/astronvim/plugins/heirline.lua
@@ -7,6 +7,7 @@ return {
       ---@param opts AstroCoreOpts
       opts = function(_, opts)
         local maps = opts.mappings
+        ---@cast maps AstroCoreMappings
         maps.n["<Leader>bb"] = {
           function()
             require("astroui.status.heirline").buffer_picker(function(bufnr) vim.api.nvim_win_set_buf(0, bufnr) end)

--- a/lua/astronvim/plugins/none-ls.lua
+++ b/lua/astronvim/plugins/none-ls.lua
@@ -26,5 +26,5 @@ return {
     },
   },
   event = "User AstroFile",
-  opts = function(_, opts) opts.on_attach = require("astrolsp").on_attach end,
+  opts = {},
 }

--- a/lua/astronvim/plugins/resession.lua
+++ b/lua/astronvim/plugins/resession.lua
@@ -44,7 +44,7 @@ return {
   },
   opts = {
     buf_filter = function(bufnr) return require("astrocore.buffer").is_restorable(bufnr) end,
-    tab_buf_filter = function(tabpage, bufnr) return vim.tbl_contains(vim.t[tabpage].bufs, bufnr) end,
+    tab_buf_filter = function(tabpage, bufnr) return vim.tbl_contains(vim.t[tabpage].bufs or {}, bufnr) end,
     extensions = { astrocore = { enable_in_tab = true } },
   },
 }

--- a/lua/astronvim/plugins/toggleterm.lua
+++ b/lua/astronvim/plugins/toggleterm.lua
@@ -13,7 +13,11 @@ return {
           local lazygit = {
             callback = function()
               local worktree = astro.file_worktree()
-              local flags = worktree and (" --work-tree=%s --git-dir=%s"):format(worktree.toplevel, worktree.gitdir)
+              local flags = worktree
+                  and (" --work-tree=%s --git-dir=%s"):format(
+                    vim.fn.shellescape(worktree.toplevel),
+                    vim.fn.shellescape(worktree.gitdir)
+                  )
                 or ""
               astro.toggle_term_cmd { cmd = "lazygit " .. flags, direction = "float" }
             end,


### PR DESCRIPTION
**Runtime integrations**

- Make deferred notifications and setup retries recover cleanly without losing queued state.
- Preserve LSP, session, terminal, mapping, and tool-install behavior across lifecycle edge cases.

**Compatibility**

- Keep Neovim 0.11/0.12 compatibility and align DAP and mapping contracts with their runtime behavior.

**Validation**

- Passed StyLua, Selene, typos, diff checks, focused runtime tests, and a full tracked-source LuaLS audit.
